### PR TITLE
Switch to clj asts and replaces type system

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,4 +16,4 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: '1.10.3.1029'
-      - run: clojure -T:build tests
+      - run: clojure -T:build ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 errors.log
 data/
+scripts/pull_fly_logs.sh
 
 # Clojure
 pom.xml

--- a/README.md
+++ b/README.md
@@ -7,15 +7,23 @@ A genetic programming system for synthesizing programs that cover a narrow subse
 The `benchmarks` folder contains code to run `cbgp-lite` on a suite of standard benchmark problems. These can be 
 used as end-to-end tests, but are primarily meant to guide research into improvements of the code building GP method.
 
-Benchmark runs can be stared in a variety of ways, detailed below.
+Benchmark runs can be started in a variety of ways, detailed below.
 
 ### Clojure CLI
 
 Simply invoke the `run` function in one of the benchmark method repos using `-X` and the `:benchmarks` alias.
 
+The main namespaces depends on the search algorithm you want to use. For all namespaces the entrypoint is the `run`
+funciton. Currently supported search algorithm namespaces are as follows:
+
+- `erp12.cbgp-lite.benchmark.ga`
+- `erp12.cbgp-lite.benchmark.simulated-annealing`
+- `erp12.cbgp-lite.benchmark.hill-climbing`
+- `erp12.cbgp-lite.benchmark.random-search`
+
 The `:suite-ns` argument denotes the namespace of the problem suite which will serve training and test cases via
-a `read-cases` function. It also must a `problems` function that will return a map of problem metadata 
-(types, literals, ERC generators, error functions).
+a `read-cases` function. It must also have a `problems` function that will return a map of problem metadata 
+(types, literals, ERC generators, error functions) when given a map of options.
 
 The remaining arguments should be whatever is required by both the `run` function of the main namespace 
 and the `read-cases` function of the `:suite-ns`. 
@@ -23,8 +31,8 @@ and the `read-cases` function of the `:suite-ns`.
 ```
 clj -X:benchmarks erp12.cbgp-lite.benchmark.ga/run \
   :suite-ns erp12.cbgp-lite.benchmark.suite.psb \
-  :data-dir '"data/program-synthesis-benchmark-datasets/datasets"' \
-  :problem $1
+  :data-dir '"data/psb"' \
+  :problem "vectors-summed"
 ```
 
 This is the preferred approach for starting a single run.
@@ -34,13 +42,20 @@ This is the preferred approach for starting a single run.
 A python script for starting multiple runs, optionally with some number of runs happening in parallel. 
 Requires Python 3. See `python3 scripts/local_runner.py --help` for possible arguments.
 
+This is the preferred approach to starting multiple runs and capturing a log file for each. 
+
 ### Docker
 
 The `scripts/build.sh` script makes it easy to build Docker images that will perform a single run of
-a specific PSB suite problem. It takes a single argument: the problem name. The resulting image will 
-be named `fcbgp-[problem]` where `[problem]` is the problem name.
+a specific PSB suite problem. It takes a two arguments:
 
-These images can be run to create a container that will perform a single run.
+- The search algorithm to use. Choices are `ga`, `simulated-annealing`, `hill-climbing`, `random-search`.
+- The problem name.
+
+The resulting image will be named `fcbgp-[search]-[problem]` where `[search]` and `[problem]` are the arguments
+provided to the build script.
+
+Running these images in a container will perform a single run.
 
 ## Development
 
@@ -49,7 +64,3 @@ These images can be run to create a container that will perform a single run.
 ```text
 clj -T:build tests
 ```
-
-## To-Do
-
-Remove git submodule and ignore `data/` now that PSB1 problems are provided by `psb2-clojure`.

--- a/benchmarks/erp12/cbgp_lite/benchmark/hill_climbing.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/hill_climbing.clj
@@ -32,8 +32,7 @@
   ;(doseq [[k v] opts]
   ;  (println k ":" (class k) " -> " v ":" (class v)))
   (let [config (merge default-config opts)
-        task (-> opts
-                 (assoc :config config)
+        task (-> config
                  bu/read-problem
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-full-behavior))
@@ -71,10 +70,10 @@
                           :simplification-steps (:simplification-steps config)
                           :individual-factory   individual-factory})
         ;; Evaluate the final program on the unseen test cases.
-        {:keys [solution?]} (i/evaluate-full-behavior {:code        (:code best)
-                                                       :arg-symbols (:arg-symbols task)
-                                                       :cases       (:test task)
-                                                       :loss-fns    (:loss-fns task)})]
+        {:keys [solution?]} (i/evaluate-full-behavior {:func     (:func best)
+                                                       :cases    (:test task)
+                                                       :loss-fns (:loss-fns task)
+                                                       :penalty  (:penalty default-config)})]
     (log/info "BEST INDIVIDUAL" best)
     (log/info "BEST CODE" (let [code (:code best)]
                             (if (coll? code)
@@ -88,11 +87,3 @@
           (log/info "SOLUTION FAILED TO GENERALIZE")))
       (log/info "SOLUTION NOT FOUND"))
     (:func best)))
-
-(comment
-
-  (run {:suite-ns 'erp12.cbgp-lite.benchmark.suite.psb
-        :data-dir "data/psb/"
-        :problem  "smallest"})
-
-  )

--- a/benchmarks/erp12/cbgp_lite/benchmark/random_search.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/random_search.clj
@@ -27,8 +27,7 @@
   ;(doseq [[k v] opts]
   ;  (println k ":" (class k) " -> " v ":" (class v)))
   (let [config (merge default-config opts)
-        task (-> opts
-                 (assoc :config config)
+        task (-> config
                  bu/read-problem
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-until-first-failure))
@@ -55,10 +54,10 @@
                                                                          solution? :solution-found
                                                                          (> @eval-counter max-evaluations) :max-evaluations-reached))))})
         ;; Evaluate the final program on the unseen test cases.
-        {:keys [solution?]} (i/evaluate-until-first-failure {:code        (:code individual)
-                                                             :arg-symbols (:arg-symbols task)
-                                                             :cases       (:test task)
-                                                             :loss-fns    (:loss-fns task)})]
+        {:keys [solution?]} (i/evaluate-until-first-failure {:func     (:func individual)
+                                                             :cases    (:test task)
+                                                             :loss-fns (:loss-fns task)
+                                                             :penalty  (:penalty default-config)})]
     (if (= :solution-found result)
       (do
         (log/info "SOLUTION FOUND")
@@ -67,11 +66,3 @@
           (log/info "SOLUTION FAILED TO GENERALIZE")))
       (log/info "SOLUTION NOT FOUND"))
     (:func individual)))
-
-(comment
-
-  (run {:suite-ns 'erp12.cbgp-lite.benchmark.suite.psb
-        :data-dir "data/psb/"
-        :problem  "number-io"})
-
-  )

--- a/benchmarks/erp12/cbgp_lite/benchmark/simulated_annealing.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/simulated_annealing.clj
@@ -31,8 +31,7 @@
   ;(doseq [[k v] opts]
   ;  (println k ":" (class k) " -> " v ":" (class v)))
   (let [config (merge default-config opts)
-        task (-> opts
-                 (assoc :config config)
+        task (-> config
                  bu/read-problem
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-full-behavior))
@@ -70,10 +69,10 @@
                           :simplification-steps (:simplification-steps config)
                           :individual-factory   individual-factory})
         ;; Evaluate the final program on the unseen test cases.
-        {:keys [solution?]} (i/evaluate-full-behavior {:code        (:code best)
-                                                       :arg-symbols (:arg-symbols task)
-                                                       :cases       (:test task)
-                                                       :loss-fns    (:loss-fns task)})]
+        {:keys [solution?]} (i/evaluate-full-behavior {:func     (:func best)
+                                                       :cases    (:test task)
+                                                       :loss-fns (:loss-fns task)
+                                                       :penalty  (:penalty default-config)})]
     (log/info "BEST INDIVIDUAL" best)
     (log/info "BEST CODE" (let [code (:code best)]
                             (if (coll? code)

--- a/benchmarks/erp12/cbgp_lite/benchmark/utils.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/utils.clj
@@ -1,15 +1,13 @@
-(ns erp12.cbgp-lite.benchmark.utils
-  (:require [taoensso.timbre :as log]))
+(ns erp12.cbgp-lite.benchmark.utils)
 
 (defn read-problem
-  [{:keys [suite-ns problem config]}]
+  [{:keys [suite-ns problem] :as config}]
   (require suite-ns)
   (let [suite-ns (find-ns suite-ns)
         suite-problems ((ns-resolve suite-ns 'problems) config)
         problem-info (get suite-problems (name problem))
-        read-cases (ns-resolve suite-ns 'read-cases)
-        task (merge config (read-cases config) problem-info)]
-    task))
+        read-cases (ns-resolve suite-ns 'read-cases)]
+    (merge config (read-cases config) problem-info)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; ERC Generators
@@ -22,15 +20,23 @@
   [magnitude]
   #(- (rand-int (inc (* 2 magnitude))) magnitude))
 
+(defn rand-char
+  []
+  (rand-nth (concat [\newline \tab] (map char (range 32 127)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Loss Function Utils
 
 (defn round
   "Round a double to the given precision (number of significant digits)"
   [precision n]
-  (let [factor (Math/pow 10 precision)]
-    (/ (Math/round (* n factor)) factor)))
+  (if (nil? n)
+    nil
+    (let [factor (Math/pow 10 precision)]
+      (/ (Math/round (* n factor)) factor))))
 
 (defn absolute-distance
   [actual expected]
-  (Math/abs (- actual expected)))
+  (if (or (nil? actual) (nil? expected))
+    nil
+    (Math/abs (- actual expected))))

--- a/build.clj
+++ b/build.clj
@@ -1,30 +1,8 @@
 (ns build
   (:require [clojure.tools.build.api :as b]
-             [org.corfield.build :as bb]))
-
-(defn tests
-  [opts]
-  (bb/run-tests opts))
+            [org.corfield.build :as bb]))
 
 (defn ci
-  [opts]
-  (-> opts
-      bb/run-tests
-      bb/clean
-      bb/uber))
-
-(defn build-psb1
-  [opts]
-  (ci (merge opts {:lib 'erp12/cbgp-lite-psb1
-                   :main 'erp12.cbgp-lite.benchmark.psb
-                   :basis (b/create-basis {:project "deps.edn"
-                                           :aliases [:benchmarks]})
-                   :src-dirs ["src" "benchmarks"]})))
-
-;(defn build-psb2
-;      [opts]
-;      (ci (merge opts {:lib 'erp12/cbgp-lite-psb2
-;                       :main 'erp12.cbgp-lite.benchmark.psb2
-;                       :basis (b/create-basis {:project "deps.edn"
-;                                               :aliases [:benchmarks]})
-;                       :src-dirs ["src" "benchmarks"]})))
+      [opts]
+      (-> opts
+          bb/run-tests))

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,18 @@
 {:path    ["src"]
  :deps    {org.clojure/core.match           {:mvn/version "1.0.0"}
            com.taoensso/timbre              {:mvn/version "5.1.2"}
-           io.github.erp12/schema-inference {:git/sha "214e39702037468eb2a8fa62bd4aabd1a2330b93"}
-           io.github.erp12/ga-clj           {:git/sha "b91f36d19a352c4d6d26f23d4ee8ffdc8a11e596"}
+           io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
+           io.github.erp12/ga-clj           {:git/sha "4d5789f751a8c7ea5edde2f1a0e319221545fb56"}
            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
- :aliases {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.5.0" :git/sha "2ceb95a"}}
+ :aliases {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}}
                         :ns-default build}
            :test       {:extra-paths ["test"]
-                        :extra-deps  {expectations/clojure-test   {:mvn/version "1.2.1"}
-                                      pjstadig/humane-test-output {:mvn/version "0.11.0"}
-                                      com.cognitect/test-runner   {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                                   :git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                        :extra-deps  {expectations/clojure-test {:mvn/version "1.2.1"}
+                                      meander/epsilon           {:mvn/version "0.0.650"}
+                                      com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                                 :git/tag "v0.5.0" :git/sha "b3fd0d2"}}
                         :main-opts   ["-m" "cognitect.test-runner"]
                         :exec-fn     cognitect.test-runner.api/test}
            :benchmarks {:extra-paths ["benchmarks"]
                         :extra-deps  {org.clojure/tools.cli    {:mvn/version "1.0.206"}
-                                      net.clojars.schneau/psb2 {:mvn/version "1.1.1"}}}
-           :profile    {:extra-deps {com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.0-alpha1"}}}}}
+                                      net.clojars.schneau/psb2 {:mvn/version "1.1.1"}}}}}

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime
 from functools import partial
 import subprocess
-from multiprocessing import Pool, cpu_count
+from multiprocessing import Pool
 
 
 def run_cmd(opts: argparse.Namespace, run_id: int) -> str:
@@ -54,8 +54,8 @@ def cli_opts() -> argparse.ArgumentParser:
     parser.add_argument(
         "--parallelism",
         type=int,
-        default=cpu_count(),
-        help="The number of runs that can be running concurrently.",
+        default=1,
+        help="The number of runs to perform concurrently. If runs are multi-threaded, recommend this be 1.",
     )
     return parser
 
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 Example:
 
 python3 scripts/local_runner.py \
-    --search "simulated-annealing" \
+    --search "ga" \
     --problem "vectors-summed" \
     --data-dir "./data/psb/" \
     --num-runs 3 \

--- a/scripts/pull_fly_logs.sh
+++ b/scripts/pull_fly_logs.sh
@@ -1,0 +1,1 @@
+scp -r erp12@fly.hampshire.edu:/home/erp12/runs/fcbgp/psb ./data/logs

--- a/scripts/start_run.sh
+++ b/scripts/start_run.sh
@@ -1,0 +1,7 @@
+problem=$1
+search=$2
+
+clj -X:benchmarks erp12.cbgp-lite.benchmark.$search/run \
+    :suite-ns erp12.cbgp-lite.benchmark.suite.psb \
+    :data-dir '"data/psb/"' \
+    :problem "$problem"

--- a/src/erp12/cbgp_lite/lang/compile.clj
+++ b/src/erp12/cbgp_lite/lang/compile.clj
@@ -1,47 +1,77 @@
 (ns erp12.cbgp-lite.lang.compile
-  (:require [clojure.core.match :refer [match]]
-            [clojure.walk :as w]
+  (:require [clojure.walk :as w]
+            [clojure.walk]
             [erp12.cbgp-lite.lang.lib :as lib]
-            [erp12.schema-inference.ast :as ast]
-            [erp12.schema-inference.inference :as inf]
-            [erp12.schema-inference.schema :as sch]
-            [taoensso.timbre :as log])
-  (:import (clojure.lang Compiler$CompilerException)))
+            [erp12.cbgp-lite.lang.schema :as schema]))
+
+;(def types-seen (atom {}))
+
+;;; @todo Move to schema-inference
+;(defn tap-nodes
+;  [f tree]
+;  (w/walk (partial tap-nodes f) identity (f tree)))
+;
+;;; @todo Move to schema-inference
+;(defn s-vars
+;  [schema]
+;  (let [x (transient #{})]
+;    (tap-nodes
+;      (fn [node]
+;        (when (= (:type node) :s-var)
+;          (conj! x (:sym node)))
+;        node)
+;      schema)
+;    (persistent! x)))
+;
+;(defn canonical-type
+;  [type]
+;  (let [subs (into {} (map-indexed (fn [i s] [s (symbol (str "S" i))])
+;                                   (sort (s-vars type))))]
+;    (walk/postwalk-replace subs type)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; State Manipulation
 
-(defn box-ast
-  "Wrap the AST in a map with a field for the inferred type."
-  [ast env]
-  {:ast  ast
-   :type (inf/infer-schema env ast)})
+;(defn box-ast
+;  "Wrap the AST in a map with a field for the inferred type."
+;  [ast env]
+;  {::ast  ast
+;   ::type (si/infer-schema ast env)})
 
 (def empty-state
-  {:asts (list)
-   :push []
-   :vars []})
+  {:asts   (list)
+   :push   []
+   :locals []})
 
 (defn push-ast
   "Push the `ast` to the AST stack in the `state`."
   [ast state]
+  ;; @todo Remove me, I am slow!
+  ;(swap! types-seen
+  ;       (fn [m t] (assoc m t (inc (get m t 0))))
+  ;       (canonical-type (::type ast)))
   (update state :asts #(conj % ast)))
 
-(defn nth-var
+(defn nth-local
   "Get the nth variable from the state using modulo to ensure `n` always selects a
   variable unless no variables are bound in the state. If there are no variables,
   returns nil."
   [n state]
-  (let [all-vars (get state :vars)]
-    (if (empty? all-vars)
+  (let [locals (get state :locals)]
+    (if (empty? locals)
       nil
-      (nth all-vars (mod n (count all-vars))))))
+      (nth locals (mod n (count locals))))))
 
 (defn macro?
-  [ast]
-  (and (vector? ast)
-       (= (first ast) :var)
-       (contains? lib/macros (second ast))))
+  [{:keys [op] :as ast}]
+  (let [sym (case op
+              :var (:var ast)
+              :local (:name ast)
+              :VAR (:sym ast)
+              nil)]
+    (if sym
+      (contains? lib/macros sym)
+      false)))
 
 (defn pop-ast
   "Get the top AST from the ast stack of `state`.
@@ -60,7 +90,7 @@
          {:ast   :none
           :state state}
 
-         (or (not (macro? (:ast ast))) allow-macros)
+         (or (not (macro? (::ast ast))) allow-macros)
          {:ast   ast
           :state (assoc state :asts (concat acc (rest remaining)))}
 
@@ -85,10 +115,10 @@
         :state    state
         :bindings {}}
        (let [ast (first remaining)
-             subs (sch/safe-mgu unify-with (:type ast))]
-         (if (and subs
+             subs (schema/mgu unify-with (::type ast))]
+         (if (and (not (schema/mgu-failure? subs))
                   (or allow-macros
-                      (not (macro? (:ast ast)))))
+                      (not (macro? (::ast ast)))))
            {:ast      ast
             :state    (assoc state :asts (concat acc (rest remaining)))
             :bindings subs}
@@ -104,8 +134,12 @@
     (if (empty? remaining)
       {:ast   :none
        :state state}
-      (let [ast (first remaining)]
-        (if (sch/fn-schema? (:type ast))
+      (let [ast (first remaining)
+            schema-type (get-in ast [::type :type])
+            schema-type (if (= schema-type :scheme)
+                          (get-in ast [::type :body :type])
+                          schema-type)]
+        (if (= schema-type :=>)
           {:ast   ast
            :state (assoc state :asts (concat acc (rest remaining)))}
           (recur (rest remaining)
@@ -119,163 +153,189 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Push to AST Compilation
 
-;(defn ->pprint
-;  [x]
-;  (println)
-;  (clojure.pprint/pprint x)
-;  x)
+(declare push->ast)
 
-;; @todo Break this into multiple private functions to make testing easier.
+(defmulti compile-step (fn [{:keys [push-unit]}] (:gene push-unit)))
+
+(defmethod compile-step :lit
+  [{:keys [push-unit state]}]
+  ;; Literals are pushed directly to the AST stack.
+  ;; Type annotation is taken from push-unit.
+  (let [{:keys [val type]} push-unit]
+    (push-ast {::ast  {:op :const :val val}
+               ::type type}
+              state)))
+
+(defmethod compile-step :var
+  [{:keys [push-unit state type-env]}]
+  ;; Vars are pushed directly to the AST stack.
+  ;; Type is taken from the type environment.
+  (push-ast {::ast  {:op :var :var (symbol (:name push-unit))}
+             ::type (schema/instantiate (get type-env (:name push-unit)))}
+            state))
+
+(defmethod compile-step :local
+  [{:keys [push-unit state type-env]}]
+  ;; Local variable numbers are mapped to a symbol using modulo logic and
+  ;; then pushed to the AST stack.
+  (let [local-symbol (nth-local (:idx push-unit) state)]
+    (if (nil? local-symbol)
+      state
+      (push-ast {::ast  {:op :local :name local-symbol}
+                 ::type (schema/instantiate (get type-env local-symbol))}
+                state))))
+
+(defmethod compile-step :apply
+  [{:keys [state type-env]}]
+  ;; Function applications search for the first AST that returns a function.
+  ;; If none found, return state.
+  ;; If found, proceed to search for ASTs for each argument to the function.
+  ;; If one or more arguments have :s-var types, incrementally bind them.
+  (let [{boxed-ast :ast state-fn-popped :state} (pop-function-ast state)]
+    (if (= :none boxed-ast)
+      state
+      (let [{::keys [ast type]} boxed-ast]
+        (loop [remaining-arg-types (schema/fn-arg-schemas type)
+               bindings {}
+               args []
+               new-state state-fn-popped]
+          (if (empty? remaining-arg-types)
+            ;; Push an AST which calls the function to the arguments and
+            ;; box the AST with the return type of the function.
+            (push-ast {::ast  {:op   :invoke
+                               :fn   ast
+                               :args (mapv ::ast args)}
+                       ::type (schema/instantiate (schema/substitute bindings (schema/fn-ret-schema type)))}
+                      new-state)
+            (let [arg-type (first remaining-arg-types)
+                  ;; If arg-type is a t-var that we have seen before,
+                  ;; bind it to the actual same type as before.
+                  arg-type (schema/substitute bindings arg-type)
+                  is-s-var (= (:type arg-type) :s-var)
+                  ;; If arg-type is still a t-var, pop an ast of any type.
+                  ;; Otherwise, pop the AST of the expected type.
+                  {arg :ast state-arg-popped :state new-bindings :bindings}
+                  (if is-s-var
+                    (pop-ast new-state)
+                    (pop-unifiable-ast arg-type new-state))
+                  ;; If arg-type's type is an unbound s-var, bind the
+                  ;; s-var to the type of the popped AST.
+                  new-bindings (if (and is-s-var (not= arg :none))
+                                 {;; The symbol of the s-var
+                                  (:sym arg-type)
+                                  ;; The type of the var made as concrete as possible.
+                                  (schema/generalize type-env (schema/substitute new-bindings (::type arg)))}
+                                 new-bindings)]
+              (if (= :none arg)
+                state
+                (recur (rest remaining-arg-types)
+                       ;; If arg-type is has unbound t-vars that were bound during unification,
+                       ;; add them to the set of bindings.
+                       (schema/compose-substitutions bindings new-bindings)
+                       (conj args arg)
+                       state-arg-popped)))))))))
+
+(defmethod compile-step :fn
+  [{:keys [push-unit state type-env]}]
+  (let [arg-types (:arg-types push-unit)]
+    (if (empty? arg-types)
+      ;; Compile nullary function.
+      (let [{ast :ast new-state :state} (pop-ast state)]
+        (if (= :none ast)
+          state
+          (push-ast {::ast  {:op      :fn
+                             :methods [{:op     :fn-method
+                                        :params []
+                                        :body   (::ast ast)}]}
+                     ::type {:type   :=>
+                             :input  {:type :cat :children []}
+                             :output (schema/instantiate (::type ast))}}
+                    new-state)))
+      ;; Compile n-ary function
+      (let [;; Generate a unique symbol for each argument.
+            arg-vars (repeatedly (count arg-types) #(gensym "a-"))
+            ;; Compile a chunk where the arguments are "in-scope" and can appear in ASTs.
+            ;; This is the function's body.
+            fn-body-env (into type-env (map #(vector %1 %2) arg-vars arg-types))
+            body (push->ast {:push     (first (:push state))
+                             :locals   (vec (concat (:locals state) arg-vars))
+                             :ret-type {:type :s-var :sym (gensym "S")}
+                             :type-env fn-body-env})
+            state-no-body-chunk (update state :push rest)
+            ;; Filter out unused args
+            args+types (mapcat (fn [a t]
+                                 (if (schema/occurs? a body)
+                                   [[a t]]
+                                   []))
+                               arg-vars
+                               arg-types)]
+        (if (= :none body)
+          ;; @todo Should we leave the chunk on the push stack and unpack it?
+          state-no-body-chunk
+          (push-ast {::ast  {:op      :fn
+                             :methods [{:op     :fn-method
+                                        :params (mapv (fn [[a _]] {:op :binding :name a})
+                                                      args+types)
+                                        :body   (::ast body)}]}
+                     ::type {:type   :=>
+                             :input  {:type     :cat
+                                      :children (mapv second args+types)}
+                             :output (schema/instantiate (::type body))}}
+                    state-no-body-chunk))))))
+
+(defmethod compile-step :let
+  [{:keys [state type-env]}]
+  (let [{var-def :ast new-state :state} (pop-ast state)
+        ;; Still pop the "chunk" that is next on the stack.
+        ;; @todo Should we leave the chunk on the push stack and unpack it?
+        noop-state (update state :push rest)]
+    (if (= :none var-def)
+      noop-state
+      (let [;; Generate a unique symbol for the new variable.
+            local-var-symb (gensym "v-")
+            ;; Compile a chunk where the local variable is "in-scope" and can appear in ASTs.
+            body (push->ast {:push     (first (:push new-state))
+                             :locals   (vec (conj (:locals state) local-var-symb))
+                             :ret-type {:type :s-var :sym (gensym "S")}
+                             :type-env (conj type-env [local-var-symb (::type var-def)])})]
+        (if (= :none body)
+          noop-state
+          ;; Compose the new `let` AST from the local variable symbol, def, and body.
+          ;; Push the new AST to the state.
+          (push-ast {::ast  {:op       :let
+                             :bindings [{:op   :binding
+                                         :name local-var-symb
+                                         :init (::ast var-def)}]
+                             :body     (::ast body)}
+                     ::type (::type body)}
+                    (update new-state :push rest)))))))
+
 (defn push->ast
-  [{:keys [push bound-vars ret-type type-env]}]
+  [{:keys [push locals ret-type type-env dealiases]
+    :or   {dealiases lib/dealiases}}]
   (loop [state (assoc empty-state
-                 :push push
-                 :vars bound-vars)]
+                 ;; Ensure a list
+                 :push (reverse (into '() push))
+                 :locals locals)]
     (if (empty? (:push state))
-      (let [ast (:ast (pop-unifiable-ast ret-type state {:allow-macros false}))]
-        ;(println "EMIT:" ast)
+      (let [;; For Debugging
+            ;_ (do (println)
+            ;      (println "Final")
+            ;      (doseq [x state] (apply println x)))
+            ast (-> ret-type
+                    schema/instantiate
+                    (pop-unifiable-ast state {:allow-macros false})
+                    :ast
+                    (->> (w/postwalk-replace dealiases)))]
+        ;(println "\nEMIT:" ast)
         ast)
       (let [{:keys [push-unit state]} (pop-push-unit state)]
         ;; Start Debug
         ;(println)
-        ;(println push-unit)
+        ;(println "Current:" push-unit)
         ;(doseq [x state] (apply println x))
         ;; End Debug
-        (recur
-          (match push-unit
-            ;; Literals are pushed directly to the AST stack.
-            [:lit _]
-            (push-ast (box-ast push-unit type-env) state)
+        (recur (compile-step {:push-unit push-unit
+                              :type-env  type-env
+                              :state     state}))))))
 
-            ;; Variable numbers are mapped to a symbol using modulo logic and
-            ;; then pushed to the AST stack.
-            [:var (_ :guard symbol?)]
-            (push-ast (box-ast push-unit type-env) state)
-
-            ;; Variable numbers are mapped to a symbol using modulo logic and
-            ;; then pushed to the AST stack.
-            [:var (n :guard int?)]
-            (push-ast (box-ast (nth-var n state) type-env) state)
-
-            ;; Function applications search for the first AST that returns a function.
-            ;; If none found, noop.
-            ;; If found, proceed to search for ASTs for each argument to the function.
-            ;; If one or more arguments have :t-var types, incrementally bind them.
-            (_ :guard #(= :apply %))
-            (let [{boxed-ast :ast state-fn-popped :state} (pop-function-ast state)]
-              (if (= :none boxed-ast)
-                state
-                (let [{:keys [ast type]} boxed-ast]
-                  (loop [remaining-arg-types (sch/fn-arg-schemas type)
-                         bindings {}
-                         args []
-                         new-state state-fn-popped]
-                    (if (empty? remaining-arg-types)
-                      ;; Push an AST which calls the function to the arguments and
-                      ;; box the AST with the return type of the function.
-                      (push-ast {:ast  (vec (concat [:apply ast] (map :ast args)))
-                                 :type (sch/substitute-types bindings (sch/fn-ret-schemas type))}
-                                new-state)
-                      (let [arg-type (first remaining-arg-types)
-                            ;; If arg-type is a t-var that we have seen before,
-                            ;; bind it to the actual same type as before.
-                            arg-type (sch/substitute-types bindings arg-type)
-                            is-s-var (sch/s-var? arg-type)
-                            ;; If arg-type is still a t-var, pop an ast of any type.
-                            ;; Otherwise, pop the AST of the expected type.
-                            {arg :ast state-arg-popped :state new-bindings :bindings}
-                            (if is-s-var
-                              (pop-ast new-state)
-                              (pop-unifiable-ast arg-type new-state))
-                            ;; If arg-type's type is an unbound s-var, bind the
-                            ;; s-var to the type of the popped AST.
-                            new-bindings (if is-s-var
-                                           {(second arg-type) (:type arg)}
-                                           new-bindings)]
-                        (if (= :none arg)
-                          state
-                          (recur (rest remaining-arg-types)
-                                 ;; If arg-type is has unbound t-vars that were bound during unification,
-                                 ;; add them to the set of bindings.
-                                 (sch/compose-substitutions bindings new-bindings)
-                                 (conj args arg)
-                                 state-arg-popped))))))))
-
-            ;; Nullary function abstraction.
-            [:fn]
-            (let [{ast :ast new-state :state} (pop-ast state)]
-              (if (= :none ast)
-                state
-                (push-ast {:ast  [:fn [:cat] (:ast ast)]
-                           :type [:=> [:cat] (:type ast)]}
-                          new-state)))
-
-            ;; Function abstraction with at least 1 argument.
-            ;; Compiles a chunk into the body of the function where args can be referenced.
-            [:fn & arg-types]
-            (let [;; Generate a unique symbol for each argument.
-                  arg-vars (repeatedly (count arg-types) #(gensym "a-"))
-                  arg-var-asts (map #(vector :var %) arg-vars)
-                  ;; Compile a chunk where the arguments are "in-scope" and can appear in ASTs.
-                  ;; This is the function's body.
-                  fn-body-env (vec (concat type-env (map #(vector := %1 %2) arg-vars arg-types)))
-                  body (push->ast {:push       (first (:push state))
-                                   :bound-vars (vec (concat bound-vars arg-var-asts))
-                                   :ret-type   [:s-var (sch/gen-s-var)]
-                                   :type-env   fn-body-env})
-                  state-no-body-chunk (update state :push rest)]
-              (if (= :none body)
-                ;; @todo Should we leave the chunk on the push stack and unpack it?
-                state-no-body-chunk
-                (push-ast {:ast  [:fn (vec (cons :cat arg-vars)) (:ast body)]
-                           :type [:=> (vec (cons :cat arg-types)) (:type body)]}
-                          state-no-body-chunk)))
-
-            ;; Searches for an AST to define the local variable.
-            ;; Compiles a chunk into the body of the let.
-            ;; @todo Should there be N local variables?
-            (_ :guard #(= :let %))
-            (let [{var-def :ast new-state :state} (pop-ast state)
-                  ;; Still pop the "chunk" that is next on the stack.
-                  ;; @todo Should we leave the chunk on the push stack and unpack it?
-                  noop-state (update state :push rest)]
-              (if (= :none var-def)
-                noop-state
-                (let [;; Generate a unique symbol for the new variable.
-                      local-var-symb (gensym "v-")
-                      local-var [:var local-var-symb]
-                      ;; Compile a chunk where the local variable is "in-scope" and can appear in ASTs.
-                      body (push->ast {:push       (first (:push new-state))
-                                       :bound-vars (conj bound-vars local-var)
-                                       :ret-type   [:s-var (sch/gen-s-var)]
-                                       :type-env   (conj type-env [:= local-var-symb (:type var-def)])})]
-                  (if (= :none body)
-                    noop-state
-                    ;; Compose the new `let` AST from the local variable symbol, def, and body.
-                    ;; Push the new AST to the state.
-                    (push-ast {:ast  [:let [local-var (:ast var-def)] (:ast body)]
-                               :type (:type body)}
-                              (update new-state :push rest))))))))))))
-
-(defn push->clj
-  "Translates Push code into a Clojure form that returns value of type `ret-type`."
-  [{:keys [push arg-symbols return-type type-env dealiases]
-    :or   {dealiases {}}}]
-  (let [input-vars (vec (map (fn [in] [:var in]) arg-symbols))
-        ast (:ast (push->ast {:push       push
-                              :bound-vars input-vars
-                              :ret-type   return-type
-                              :type-env   type-env}))]
-    (->> ast ast/ast->form (w/postwalk-replace dealiases))))
-
-(defn synth-fn
-  "Given a vector of argument symbols and a Clojure form (`body`)
-  create a function (similar to `fn`)."
-  [args body]
-  (try
-    (eval `(fn ~(vec args) ~body))
-    (catch Compiler$CompilerException e
-      (throw (ex-info (str "Bad form: " body)
-                      {:args args
-                       :body body}
-                      e)))))

--- a/src/erp12/cbgp_lite/lang/form.clj
+++ b/src/erp12/cbgp_lite/lang/form.clj
@@ -1,0 +1,49 @@
+(ns erp12.cbgp-lite.lang.form
+  (:import (clojure.lang Compiler$CompilerException)))
+
+(defmulti ast->form (fn [{:keys [op]}] op))
+
+(defmethod ast->form :binding
+  [{:keys [name init]}]
+  (if (nil? init)
+    (symbol name)
+    [(symbol name) (ast->form init)]))
+
+(defmethod ast->form :const [{:keys [val]}] val)
+
+(defmethod ast->form :var [{:keys [var]}] (symbol var))
+
+(defmethod ast->form :local [{:keys [name]}] (symbol name))
+
+(defmethod ast->form :invoke
+  [{:keys [fn args]}]
+  (cons (ast->form fn) (map ast->form args)))
+
+(defmethod ast->form :fn
+  [{:keys [methods]}]
+  (let [{:keys [params body]} (first methods)]
+    (list 'fn
+          (mapv ast->form params)
+          (ast->form body))))
+
+(defmethod ast->form :fn-method [_]
+  (throw (ex-info "unreachable" {})))
+
+(defmethod ast->form :let
+  [{:keys [bindings body]}]
+  (let []
+    (list 'let
+          (vec (mapcat ast->form bindings))
+          (ast->form body))))
+
+(defn form->fn
+  "Given a vector of argument symbols and a Clojure form (`body`)
+  create a function (similar to `fn`)."
+  [args body]
+  (try
+    (eval `(fn ~(vec args) ~body))
+    (catch Compiler$CompilerException e
+      (throw (ex-info (str "Bad form: " body)
+                      {:args args
+                       :body body}
+                      e)))))

--- a/src/erp12/cbgp_lite/lang/schema.clj
+++ b/src/erp12/cbgp_lite/lang/schema.clj
@@ -1,0 +1,45 @@
+(ns erp12.cbgp-lite.lang.schema
+  (:require [erp12.schema-inference.impl.util :as su]
+            [clojure.walk :as w]))
+
+(defn occurs?
+  [term form]
+  (let [t (transient #{})]
+    (w/postwalk #(do (conj! t (= % term)) %) form)
+    (contains? t true)))
+
+(defn fn-arg-schemas
+  [{:keys [type] :as schema}]
+  (if (= type :scheme)
+    (fn-arg-schemas (:body schema))
+    (get-in schema [:input :children])))
+
+(defn fn-ret-schema
+  [{:keys [type] :as schema}]
+  (if (= type :scheme)
+    (fn-ret-schema (:body schema))
+    (:output schema)))
+
+(defn mgu
+  [schema1 schema2]
+  (su/mgu schema1 schema2))
+
+(defn mgu-failure?
+  [m]
+  (su/mgu-failure? m))
+
+(defn generalize
+  [env schema]
+  (su/generalize env schema))
+
+(defn instantiate
+  [schema]
+  (su/instantiate schema))
+
+(defn substitute
+  [subs schema]
+  (su/substitute subs schema))
+
+(defn compose-substitutions
+  [subs1 subs2]
+  (su/compose-substitutions subs1 subs2))

--- a/src/erp12/cbgp_lite/search/pluhsy.clj
+++ b/src/erp12/cbgp_lite/search/pluhsy.clj
@@ -1,62 +1,70 @@
 (ns erp12.cbgp-lite.search.pluhsy
   (:require [erp12.cbgp-lite.utils :as u]))
 
-(defn random-gene
-  [{:keys [gene-distribution vars lits lit-generators abstraction]
-    :as   opts}]
-  (let [kind (u/rand-weighted gene-distribution)
-        gene-val (cond
-                   (= :apply kind) :apply
-                   (= :close kind) :close
-                   (= :var kind) (u/safe-rand-nth vars)
-                   (= :local kind) (rand-int Integer/MAX_VALUE)
-                   (= :lit kind) (u/safe-rand-nth lits)
-                   (= :lit-generator kind) (when-let [gen (u/safe-rand-nth lit-generators)] (gen))
-                   (= :abstraction kind) (u/safe-rand-nth abstraction)
-                   :else (throw (ex-info (str "Unknown kind of gene: " kind)
-                                         {:gene-kind         kind
-                                          :gene-distribution gene-distribution})))]
-    (cond
-      ;; Gene value will be nil if there are no possible values (empty coll)
-      ;; for a certain gene type. Try again.
-      (nil? gene-val)
-      (recur opts)
+(defn prob-by-gene-kind
+  [genes kind-distribution]
+  (let [kind-distribution (u/weights-to-probs kind-distribution)
+        kind-prob (->> genes
+                       (map :gene)
+                       frequencies
+                       (map (fn [[kind freq]]
+                              [kind (/ (kind-distribution kind) freq)]))
+                       (into {}))]
+    (->> genes
+         (map (fn [g] [g (kind-prob (:gene g))]))
+         (into {}))))
 
-      (contains? #{:var :local} kind)
-      [:var gene-val]
+(defn make-genetic-source
+  [gene+prob]
+  (let [gene+prob (seq gene+prob)
+        weights (reductions + (map second gene+prob))
+        total (last weights)
+        choices (map vector (map first gene+prob) weights)]
+    (fn []
+      (let [r (rand total)]
+        (loop [[[el w] & more] choices]
+          (when w
+            (if (< r w)
+              (let [kind (:gene el)]
+                (case kind
+                  ;; Convert ERCs into true genes.
+                  :lit-generator {:gene :lit :val ((:fn el)) :type (:type el)}
+                  :local {:gene :local :idx (rand-int Integer/MAX_VALUE)}
+                  el))
+              (recur more))))))))
 
-      (contains? #{:lit :lit-generator} kind)
-      [:lit gene-val]
-
-      :else gene-val)))
 
 (defn random-plushy-genome
   [{:keys [min-genome-size max-genome-size genetic-source]}]
   (repeatedly (+ (rand-int (- max-genome-size min-genome-size)) min-genome-size)
               genetic-source))
 
+(def ^:private open {:gene :open})
+(def ^:private close {:gene :close})
+
 (defn plushy->push
   [plushy]
   (loop [plushy plushy
          push []]
-    (let [has-open (some #{:open} push)
-          gene (first plushy)]
+    (let [has-open (some #{open} push)
+          gene (first plushy)
+          kind (:gene gene)]
       (if (empty? plushy)
         (if has-open
           ;; If there is no more plushy genes but the push code still contains
-          ;; an :open, add :close to the plushy genome and recur.
-          (recur '(:close) push)
+          ;; an open, add a close to the plushy genome and recur.
+          (recur (list close) push)
           ;; Otherwise, return the translated Push code.
           push)
         (cond
-          (= gene :close)
+          (= kind :close)
           (if has-open
             ;; If there is an :open for this :close gene to close, wrap the Push
             ;; code after the :open with in a list.
             (recur (rest plushy)
                    (let [post-open (->> push
                                         reverse
-                                        (take-while (comp not #{:open}))
+                                        (take-while (comp not #{open}))
                                         reverse
                                         vec)
                          open-idx (- (count push) (count post-open) 1)
@@ -69,11 +77,10 @@
           ;; If the kind of gene implies the opening of a chunk (only `let` and `fn` genes)
           ;; prepend an :open to the plushy genome and append the gene to the Push code
           ;; so that it is followed by nested Push "chunk".
-          (or (= gene :let)
-              (and (vector? gene)
-                   (= (first gene) :fn)
-                   (> (count gene) 1)))
-          (recur (cons :open (rest plushy))
+          (or (= kind :let)
+              (and (= kind :fn)
+                   (not (empty? (:arg-types gene)))))
+          (recur (cons open (rest plushy))
                  (conj push gene))
 
           ;; Any other gene is added to the end of the Push code.

--- a/src/erp12/cbgp_lite/utils.clj
+++ b/src/erp12/cbgp_lite/utils.clj
@@ -6,6 +6,15 @@
   [coll]
   (first (filter some? coll)))
 
+(defn weights-to-probs
+  "Normalizes the numeric values of `m` into a proportion of the total.
+  Returns a map with values that sum to 1."
+  [m]
+  (let [total (reduce + (vals m))]
+    (->> m
+         (map (fn [[k w]] [k (/ w total)]))
+         (into {}))))
+
 (defn rand-weighted
   [m]
   (let [weights (reductions + (vals m))
@@ -17,6 +26,7 @@
           (if (< choice w)
             c
             (recur more)))))))
+
 
 (defn safe-rand-nth
   [coll]

--- a/test/erp12/cbgp_lite/lang/compile_test.clj
+++ b/test/erp12/cbgp_lite/lang/compile_test.clj
@@ -1,197 +1,527 @@
 (ns erp12.cbgp-lite.lang.compile-test
-  (:require [clojure.test :refer :all]
-            [erp12.cbgp-lite.lang.compile :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [clojure.walk :as w]
             [erp12.cbgp-lite.lang.compile :as c]
+            [erp12.cbgp-lite.lang.form :as f]
             [erp12.cbgp-lite.lang.lib :as lib]
-            [erp12.cbgp-lite.search.pluhsy :as pl]))
+            [meander.epsilon :as m])
+  (:import (java.io StringWriter)))
 
-(def environment
-  (mapv (fn [[symb annotation]] [:= symb annotation])
-        lib/library))
+(defmacro matches?
+  [template value]
+  (let [template (w/postwalk (fn [node]
+                               (if (and (symbol? node)
+                                        (str/starts-with? (name node) "?"))
+                                 `(m/pred some? ~node)
+                                 node))
+                             template)]
+    `(m/match ~value
+              ~template true
+              ~(quote ?else) false)))
 
+(deftest matches?-test
+  (is (matches? {:op ?_ :name ?a}
+                {:op :var :name 'foo}))
+  (is (not (matches? {:op ?_ :name ?a}
+                     {:op :var :var 'foo})))
+  (is (not (matches? {:op :VAR :name ?a}
+                     {:op :var :name 'foo})))
+  (is (matches? {:a ?x :b ?x}
+                {:a 1 :b 1 :c "extra"})))
 
-(deftest box-ast-test
-  (is (= {:ast [:lit 1] :type int?}
-         (box-ast [:lit 1] [])))
-  (is (= {:ast [:lit [1 2 3]] :type [:vector int?]}
-         (box-ast [:lit [1 2 3]] []))))
+;(deftest box-ast-test
+;  (is (= (c/box-ast {:op :const :val 1} lib/type-env)
+;         {::c/ast  {:op :const :val 1}
+;          ::c/type {:type 'int?}}))
+;  (is (= (c/box-ast {:op :const :val [1 2 3]} lib/type-env)
+;         {::c/ast  {:op :const :val [1 2 3]}
+;          ::c/type {:type :vector :child {:type 'int?}}})))
 
-(deftest nth-var-test
-  (is (= {:ast [:var 'x] :type int?}
-         (nth-var 100 {:vars [{:ast [:var 'x] :type int?}]})))
-  (is (= nil (nth-var 100 {:vars []}))))
+(deftest nth-local-test
+  (is (= (c/nth-local 100 {:locals ['x 'y 'z]}) 'y))
+  (is (nil? (c/nth-local 100 {:locals []}))))
 
 (deftest macro?-test
-  (is (macro? [:var 'if]))
-  (is (not (macro? [:var 'float-add]))))
+  (is (c/macro? {:op :var :var 'if}))
+  (is (not (c/macro? {:op :var :var 'double-add}))))
 
 (deftest pop-ast-test
-  (is (= {:ast :none :state empty-state}
-         (pop-ast empty-state)))
-  (is (= {:ast   {:ast :_ :type int?}
-          :state {:asts (list)}}
-         (pop-ast {:asts [{:ast :_ :type int?}]})))
+  (is (= (c/pop-ast c/empty-state)
+         {:ast :none :state c/empty-state}))
+  (is (= (c/pop-ast {:asts [{::c/ast  :_
+                             ::c/type {:type 'int?}}]})
+         {:ast   {::c/ast :_ ::c/type {:type 'int?}}
+          :state {:asts (list)}}))
   (testing "popping functions of any type"
-    (is (= {:ast   {:ast :_ :type [:=> [:cat int?] string?]}
-            :state {:asts (list {:ast :_ :type boolean?})}}
-           (pop-function-ast {:asts (list {:ast :_ :type boolean?}
-                                          {:ast :_ :type [:=> [:cat int?] string?]})})))
-    (is (= {:ast   {:ast  :_
-                    :type {:s-vars ['a]
-                           :body   [:=> [:cat [:s-var 'a]] [:s-var 'a]]}}
-            :state {:asts (list {:ast :_ :type boolean?})}}
-           (pop-function-ast {:asts (list {:ast :_ :type boolean?}
-                                          {:ast  :_
-                                           :type {:s-vars ['a]
-                                                  :body   [:=> [:cat [:s-var 'a]] [:s-var 'a]]}})}))))
+    (is (= (c/pop-function-ast {:asts (list {::c/ast  :_
+                                             ::c/type {:type 'boolean?}}
+                                            {::c/ast  :_
+                                             ::c/type {:type   :=>
+                                                       :input  {:type     :cat
+                                                                :children [{:type 'int?}]}
+                                                       :output {:type 'string?}}})})
+           {:ast   {::c/ast  :_
+                    ::c/type {:type   :=>
+                              :input  {:type     :cat
+                                       :children [{:type 'int?}]}
+                              :output {:type 'string?}}}
+            :state {:asts (list {::c/ast  :_
+                                 ::c/type {:type 'boolean?}})}}))
+
+    (is (= (c/pop-function-ast {:asts (list {::c/ast  :_
+                                             ::c/type {:type 'boolean?}}
+                                            {::c/ast  :_
+                                             ::c/type {:type   :scheme
+                                                       :s-vars ['a]
+                                                       :body   {:type   :=>
+                                                                :input  {:type     :cat
+                                                                         :children [{:type :s-var :sym 'a}]}
+                                                                :output {:type :s-var :sym 'a}}}})})
+           {:ast   {::c/ast  :_
+                    ::c/type {:type   :scheme
+                              :s-vars ['a]
+                              :body   {:type   :=>
+                                       :input  {:type     :cat
+                                                :children [{:type :s-var :sym 'a}]}
+                                       :output {:type :s-var :sym 'a}}}}
+            :state {:asts (list {::c/ast  :_
+                                 ::c/type {:type 'boolean?}})}})))
+
   (testing "popping function of specific type"
-    (is (= {:ast      {:ast :_ :type [:=> [:cat int?] string?]}
-            :state    {:asts (list {:ast :_ :type boolean?})}
-            :bindings {}}
-           (pop-unifiable-ast [:=> [:cat int?] string?]
-                              {:asts (list {:ast :_ :type boolean?}
-                                           {:ast :_ :type [:=> [:cat int?] string?]})}))))
+    (testing "monomorphic function"
+      (is (= (c/pop-unifiable-ast {:type   :=>
+                                   :input  {:type     :cat
+                                            :children [{:type 'int?}]}
+                                   :output {:type 'string?}}
+                                  {:asts (list {::c/ast  :_
+                                                ::c/type {:type 'boolean?}}
+                                               {::c/ast  :_
+                                                ::c/type {:type   :=>
+                                                          :input  {:type     :cat
+                                                                   :children [{:type 'int?}]}
+                                                          :output {:type 'string?}}})})
+             {:ast      {::c/ast  :_
+                         ::c/type {:type   :=>
+                                   :input  {:type     :cat
+                                            :children [{:type 'int?}]}
+                                   :output {:type 'string?}}}
+              :state    {:asts (list {::c/ast  :_
+                                      ::c/type {:type 'boolean?}})}
+              :bindings {}})))
+    (testing "failed polymorphic function"
+      (let [init-state {:asts (list {::c/ast  :_
+                                     ::c/type {:type 'boolean?}}
+                                    {::c/ast  :_
+                                     ::c/type {:type   :=>
+                                               :input  {:type     :cat
+                                                        :children [{:type :s-var :sym 'a}]}
+                                               :output {:type :s-var :sym 'a}}})}]
+        (is (= (c/pop-unifiable-ast {:type   :=>
+                                     :input  {:type     :cat
+                                              :children [{:type 'int?}]}
+                                     :output {:type 'string?}}
+                                    init-state)
+               {:ast      :none
+                :state    init-state
+                :bindings {}}))))
+    (testing "successful polymorphic function"
+      (is (= (c/pop-unifiable-ast {:type   :=>
+                                   :input  {:type     :cat
+                                            :children [{:type 'int?}]}
+                                   :output {:type 'string?}}
+                                  {:asts (list {::c/ast  :_
+                                                ::c/type {:type 'boolean?}}
+                                               {::c/ast  :_
+                                                ::c/type {:type   :=>
+                                                          :input  {:type     :cat
+                                                                   :children [{:type :s-var :sym 'a}]}
+                                                          :output {:type :s-var :sym 'b}}})})
+             {:ast      {::c/ast  :_
+                         ::c/type {:type   :=>
+                                   :input  {:type     :cat
+                                            :children [{:type :s-var :sym 'a}]}
+                                   :output {:type :s-var :sym 'b}}}
+              :state    {:asts (list {::c/ast  :_
+                                      ::c/type {:type 'boolean?}})}
+              :bindings {'a {:type 'int?}
+                         'b {:type 'string?}}}))))
+
   (testing "skip macros"
-    (is (= {:ast   {:ast [:var '+] :type :_}
-            :state {:asts (list {:ast [:var 'if] :type :_})}}
-           (pop-ast {:asts (list {:ast [:var 'if] :type :_}
-                                 {:ast [:var '+] :type :_})})))))
+    (is (= (c/pop-ast {:asts (list {::c/ast {:op :var :var 'if} :type :_}
+                                   {::c/ast {:op :var :var '+} :type :_})})
+           {:ast   {::c/ast {:op :var :var '+} :type :_}
+            :state {:asts (list {::c/ast {:op :var :var 'if} :type :_})}}))))
+
+(deftest compile-step-test
+  (testing "compile lit"
+    (is (= (c/compile-step {:push-unit {:gene :lit :val 1 :type {:type 'int?}}
+                            :state     c/empty-state
+                            :type-env  {}})
+           {:asts   (list {::c/ast  {:op :const :val 1}
+                           ::c/type {:type 'int?}})
+            :push   []
+            :locals []})))
+  (testing "compile var"
+    (is (matches? {:asts   ({::c/ast  {:op :var :var '=}
+                             ::c/type {:type   :=>
+                                       :input  {:type     :cat
+                                                :children [{:type :s-var :sym ?a}
+                                                           {:type :s-var :sym ?b}]}
+                                       :output {:type 'boolean?}}})
+                   :push   []
+                   :locals []}
+                  (c/compile-step {:push-unit {:gene :var :name '=}
+                                   :state     c/empty-state
+                                   :type-env  lib/type-env}))))
+  (testing "compile local"
+    (is (= c/empty-state
+           (c/compile-step {:push-unit {:gene :local :idx 3}
+                            :state     c/empty-state
+                            :type-env  lib/type-env})))
+    (is (= {:asts   (list {::c/ast  {:op :local :name 'x}
+                           ::c/type {:type 'int?}})
+            :push   []
+            :locals ['x]}
+           (c/compile-step {:push-unit {:gene :local :idx 3}
+                            :state     (assoc c/empty-state :locals ['x])
+                            :type-env  {'x {:type 'int?}}}))))
+  (testing "compile apply"
+    (is (= (c/compile-step {:push-unit {:gene :apply}
+                            :state     (assoc c/empty-state
+                                         :asts (list {::c/ast  {:op :const :val 2}
+                                                      ::c/type {:type 'int?}}
+                                                     {::c/ast  {:op :var :var 'int-sub}
+                                                      ::c/type (lib/type-env 'int-sub)}
+                                                     {::c/ast  {:op :const :val 1}
+                                                      ::c/type {:type 'int?}}))
+                            :type-env  lib/type-env})
+
+           {:asts   (list {::c/ast  {:op   :invoke
+                                     :fn   {:op :var :var 'int-sub}
+                                     :args [{:op :const :val 2}
+                                            {:op :const :val 1}]}
+                           ::c/type {:type 'int?}})
+            :push   []
+            :locals []}))
+    (is (= (c/compile-step {:push-unit {:gene :apply}
+                            :state     (assoc c/empty-state
+                                         :asts (list {::c/ast  {:op :const :val 1}
+                                                      ::c/type {:type 'int?}}
+                                                     {::c/ast  {:op :const :val -1}
+                                                      ::c/type {:type 'int?}}
+                                                     {::c/ast  {:op :var :var 'if}
+                                                      ::c/type (lib/type-env 'if)}
+                                                     {::c/ast  {:op :local :name 'x}
+                                                      ::c/type {:type 'boolean?}})
+                                         :locals ['x])
+                            :type-env  (assoc lib/type-env
+                                         'x {:type 'boolean?})})
+           {:asts   (list {::c/ast  {:op   :invoke
+                                     :fn   {:op :var :var 'if}
+                                     :args [{:op :local :name 'x}
+                                            {:op :const :val 1}
+                                            {:op :const :val -1}]}
+                           ::c/type {:type 'int?}})
+            :push   []
+            :locals ['x]}))
+    ;; @todo Test when args are missing
+    )
+  (testing "compile fn"
+    (is (matches? {:asts   ({::c/ast  {:op      :fn
+                                       :methods [{:op     :fn-method
+                                                  :params [{:op :binding :name ?a}]
+                                                  :body   {:op :local :name ?a}}]}
+                             ::c/type {:type   :=>
+                                       :input  {:type     :cat
+                                                :children [{:type int?}]}
+                                       :output {:type int?}}})
+                   :push   []
+                   :locals []}
+                  (c/compile-step {:push-unit {:gene      :fn
+                                               :arg-types [{:type 'int?}]}
+                                   :state     (assoc c/empty-state
+                                                :asts (list)
+                                                :push [[{:gene :local :idx 1}]])
+                                   :type-env  {}})))
+    (testing "nullary fn"
+      (is (= (c/compile-step {:push-unit {:gene :fn}
+                              :state     (assoc c/empty-state
+                                           :asts (list {::c/ast  {:op :var :var 'x}
+                                                        ::c/type {:type 'string?}})
+                                           :push [])
+                              :type-env  {'x {:type 'string?}}})
+             {:asts   (list {::c/ast  {:op      :fn
+                                       :methods [{:op     :fn-method
+                                                  :params []
+                                                  :body   {:op :var :var 'x}}]}
+                             ::c/type {:type   :=>
+                                       :input  {:type :cat :children []}
+                                       :output {:type 'string?}}})
+              :push   []
+              :locals []}))))
+  (testing "compile let"
+    (is (matches? {:asts   ({::c/ast  {:op       :let
+                                       :bindings [{:op   :binding
+                                                   :name ?v
+                                                   :init {:op :const :val 1}}]
+                                       :body     {:op :local :name ?v}}
+                             ::c/type {:type int?}})
+                   :push   []
+                   :locals []}
+                  (c/compile-step {:push-unit {:gene :let}
+                                   :state     (assoc c/empty-state
+                                                :asts (list {::c/ast  {:op :const :val 1}
+                                                             ::c/type {:type 'int?}})
+                                                :push [[{:gene :local :idx 1}]])
+                                   :type-env  {}})))))
+
+(deftest push->ast-test
+  (testing "composing schemes"
+    (is (matches? {::c/ast  {:op   :invoke
+                             :fn   {:op :var :var 'identity}
+                             :args [{:op :var :var 'poly-f}]}
+                   ::c/type {:type   :=>
+                             :input  {:type     :cat
+                                      :children [{:type :s-var :sym ?x}]}
+                             :output {:type :s-var :sym ?y}}}
+                  (c/push->ast {:push     [{:gene :var :name 'poly-f}
+                                           {:gene :var :name 'identity}
+                                           {:gene :apply}]
+                                :locals   []
+                                :ret-type {:type   :scheme
+                                           :s-vars ['a 'b]
+                                           :body   {:type   :=>
+                                                    :input  {:type     :cat
+                                                             :children [{:type :s-var :sym 'a}]}
+                                                    :output {:type :s-var :sym 'b}}}
+                                :type-env {'identity {:type   :scheme
+                                                      :s-vars ['c]
+                                                      :body   {:type   :=>
+                                                               :input  {:type     :cat
+                                                                        :children [{:type :s-var :sym 'c}]}
+                                                               :output {:type :s-var :sym 'c}}}
+                                           'poly-f   {:type   :scheme
+                                                      :s-vars ['d 'e]
+                                                      :body   {:type   :=>
+                                                               :input  {:type     :cat
+                                                                        :children [{:type :s-var :sym 'd}]}
+                                                               :output {:type :s-var :sym 'e}}}}}))))
+  (testing "pruning unused function args"
+    (is (= (c/push->ast {:push     [{:gene      :fn
+                                     :arg-types [{:type 'int?}
+                                                 {:type 'string?}]}
+                                    [{:gene :var :name 'x}]]
+                         :locals   []
+                         :ret-type {:type   :=>
+                                    :input  {:type :cat :children []}
+                                    :output {:type 'int?}}
+                         :type-env {'x {:type 'int?}}})
+           {::c/ast  {:op      :fn
+                      :methods [{:op     :fn-method
+                                 :params []
+                                 :body   {:op :var :var 'x}}]}
+            ::c/type {:type   :=>
+                      :input  {:type :cat :children []}
+                      :output {:type 'int?}}})))
+  (testing "polymorphic thunk"
+    (is (matches? {::c/ast  {:op      :fn
+                             :methods [{:op     :fn-method
+                                        :params []
+                                        :body   {:op :var :var identity}}]}
+                   ::c/type {:type   :=>
+                             :input  {:type :cat :children []}
+                             :output {:type   :=>
+                                      :input  {:type :cat :children [{:type :s-var :sym ?a}]}
+                                      :output {:type :s-var :sym ?a}}}}
+                  (c/push->ast {:push     [{:gene :var :name 'identity}
+                                           {:gene :fn}]
+                                :locals   []
+                                :ret-type {:type   :=>
+                                           :input  {:type :cat :children []}
+                                           :output {:type   :=>
+                                                    :input  {:type :cat :children [{:type 'int?}]}
+                                                    :output {:type 'int?}}}
+                                :type-env {'identity {:type   :scheme
+                                                      :s-vars ['a]
+                                                      :body   {:type   :=>
+                                                               :input  {:type :cat :children [{:type :s-var :sym 'a}]}
+                                                               :output {:type :s-var :sym 'a}}}}})))))
 
 (deftest simple-math-test
-  ;; Add 100 to the input.
-  (let [push [[:lit 100]
-              [:var 'in1]
-              [:var 'int-add]
-              :apply]
-        code (push->clj {:push        push
-                         :arg-symbols ['in1]
-                         :return-type int?
-                         :type-env    (conj environment [:= 'in1 int?])
-                         :dealiases   lib/dealiases})
-        f (synth-fn ['in1] code)]
-    (is (= 100 (f 0)))
-    (is (= 200 (f 100)))
-    ;; @todo How test the contents of `code` with random variable names?
-    ))
+  ;; Add 100 to input.
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :lit :val 100 :type {:type 'int?}}
+                                                        {:gene :local :idx 0}
+                                                        {:gene :var :name 'int-add}
+                                                        {:gene :apply}]
+                                            :locals    ['in1]
+                                            :ret-type  {:type 'int?}
+                                            :type-env  (assoc lib/type-env
+                                                         'in1 {:type 'int?})
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type 'int?}))
+        form (f/ast->form ast)
+        _ (is (= form '(+ in1 100)))
+        func (eval `(fn [~'in1] ~form))]
+    (is (= 100 (func 0)))
+    (is (= 101 (func 1)))))
 
 (deftest conditional-logic-test
   ;; If input < 1000, return "small" else "large".
-  (is (= '(if (< in1 1000) "small" "large")
-         (push->clj {:push        [[:lit "large"]
-                                   [:lit "small"]
-                                   [:lit 1000]
-                                   [:var 0]
-                                   [:var 'int-lt]
-                                   :apply
-                                   [:var 'if]
-                                   :apply]
-                     :arg-symbols ['in1]
-                     :return-type string?
-                     :type-env    (conj environment [:= 'in1 int?])
-                     :dealiases   lib/dealiases}))))
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :lit :val "large" :type {:type 'string?}}
+                                                        {:gene :lit :val "small" :type {:type 'string?}}
+                                                        {:gene :lit :val 1000 :type {:type 'int?}}
+                                                        {:gene :local :idx 0}
+                                                        {:gene :var :name 'int-lt}
+                                                        {:gene :apply}
+                                                        {:gene :var :name 'if}
+                                                        {:gene :apply}]
+                                            :locals    ['in1]
+                                            :ret-type  {:type 'string?}
+                                            :type-env  (assoc lib/type-env
+                                                         'in1 {:type 'int?})
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type 'string?}))
+        form (f/ast->form ast)
+        _ (is (= form '(if (< in1 1000) "small" "large")))
+        func (eval `(fn [~'in1] ~form))]
+    (is (= (func 0) "small"))
+    (is (= (func 1000) "large"))
+    (is (= (func 2000) "large"))))
 
 (deftest let-binding-test
   ;; Square and then double the input.
-  (let [push [;; [:var 0] Binds to 'in1
-              [:var 0]
-              [:var 0]
-              [:var 'int-mult]
-              :apply
-              :let
-              [;; Binds to local variable
-               [:var 1]
-               [:var 1]
-               [:var 'int-add]
-               :apply]]
-        code (push->clj {:push        push
-                         :arg-symbols ['in1]
-                         :return-type int?
-                         :type-env    (conj environment [:= 'in1 int?])
-                         :dealiases   lib/dealiases})
-        f (synth-fn ['in1] code)]
-    (is (= 0 (f 0)))
-    (is (= 2 (f 1)))
-    (is (= 8 (f 2)))))
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :local :idx 0}
+                                                        {:gene :local :idx 0}
+                                                        {:gene :var :name 'int-mult}
+                                                        {:gene :apply}
+                                                        {:gene :let}
+                                                        [{:gene :local :idx 1}
+                                                         {:gene :local :idx 1}
+                                                         {:gene :var :name 'int-add}
+                                                         {:gene :apply}]]
+                                            :locals    ['in1]
+                                            :ret-type  {:type 'int?}
+                                            :type-env  (assoc lib/type-env
+                                                         'in1 {:type 'int?})
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type 'int?}))
+        form (f/ast->form ast)
+        _ (is (matches? (let [?v (* in1 in1)]
+                          (+ ?v ?v))
+                        form))
+        func (eval `(fn [~'in1] ~form))]
+    (is (= (func 0) 0))
+    (is (= (func 2) 8))
+    (is (= (func -1) 2))))
 
 (deftest hof-with-anonymous-fn-test
   ;; Map `inc` over the elements of a vector
-  (let [push [[:lit [1 2 3]]
-              [:fn int?]
-              [;; Binds to local function argument
-               [:var 0]
-               [:var 'int-inc]
-               :apply]
-              [:var 'mapv]
-              :apply]
-        code (push->clj {:push        push
-                         :arg-symbols []
-                         :return-type [:vector int?]
-                         :type-env    environment
-                         :dealiases   lib/dealiases})
-        f (synth-fn [] code)]
-    (is (= [2 3 4] (f)))))
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :lit :val [1 2 3] :type {:type :vector :child {:type 'int?}}}
+                                                        {:gene :fn :arg-types [{:type 'int?}]}
+                                                        [{:gene :local :idx 0}
+                                                         {:gene :var :name 'int-inc}
+                                                         {:gene :apply}]
+                                                        {:gene :var :name 'mapv}
+                                                        {:gene :apply}]
+                                            :locals    []
+                                            :ret-type  {:type :vector :child {:type 'int?}}
+                                            :type-env  lib/type-env
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type :vector :child {:type 'int?}}))
+        form (f/ast->form ast)
+        _ (is (matches? (mapv (fn [?a] (inc ?a)) [1 2 3])
+                        form))
+        func (eval `(fn [] ~form))]
+    (is (= [2 3 4] (func)))))
 
 (deftest nullary-fn-test
-  (is (= '(repeatedly 5 (clojure.core/fn [] (rand)))
-         (push->clj {:push        [[:var 'rand]
-                                   :apply
-                                   [:fn]
-                                   [:lit 5]
-                                   [:var 'repeatedly]
-                                   :apply]
-                     :arg-symbols []
-                     :return-type [:vector float?]
-                     :type-env    [[:= 'rand [:=> [:cat] float?]]
-                                   [:= 'repeatedly {:s-vars '[a]
-                                                    :body   [:=> [:cat int? [:=> [:cat] [:s-var 'a]]]
-                                                             [:vector [:s-var 'a]]]}]]
-                     :dealiases   {}}))))
-
+  ;; Generate a vector of 5 random doubles.
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :var :name 'rand}
+                                                        {:gene :apply}
+                                                        {:gene :fn}
+                                                        {:gene :lit :val 5 :type {:type 'int?}}
+                                                        {:gene :var :name 'repeatedly}
+                                                        {:gene :apply}]
+                                            :locals    []
+                                            :ret-type  {:type :vector :child {:type 'double?}}
+                                            :type-env  {'rand       {:type   :=>
+                                                                     :input  {:type :cat :children []}
+                                                                     :output {:type 'double?}}
+                                                        'repeatedly {:type   :scheme
+                                                                     :s-vars ['a]
+                                                                     :body   {:type   :=>
+                                                                              :input  {:type     :cat
+                                                                                       :children [{:type 'int?}
+                                                                                                  {:type   :=>
+                                                                                                   :input  {:type :cat :children []}
+                                                                                                   :output {:type :s-var :sym 'a}}]}
+                                                                              :output {:type  :vector
+                                                                                       :child {:type :s-var :sym 'a}}}}}
+                                            :dealiases {}})
+        _ (is (= type {:type :vector :child {:type 'double?}}))
+        form (f/ast->form ast)
+        _ (is (= form '(repeatedly 5 (fn [] (rand)))))
+        func (eval `(fn [] ~form))]
+    (doseq [x (func)]
+      (is (double? x)))))
 
 (deftest side-effects-test
-  (is (= '(do (println "Hello world!") 0)
-         (push->clj {:push        [[:lit 0]
-                                   [:lit "Hello world!"]
-                                   [:var 'println]
-                                   :apply
-                                   [:var 'do2]
-                                   :apply]
-                     :arg-symbols []
-                     :return-type int?
-                     :type-env    (mapv (fn [[symb typ]] [:= symb typ]) lib/library)
-                     :dealiases   lib/dealiases}))))
+  ;; Print hello world and return 0
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :lit :val 0 :type {:type 'int?}}
+                                                        {:gene :lit :val "Hello world!" :type {:type 'string?}}
+                                                        {:gene :var :name 'println}
+                                                        {:gene :apply}
+                                                        {:gene :var :name 'do2}
+                                                        {:gene :apply}]
+                                            :locals    []
+                                            :ret-type  {:type 'int?}
+                                            :type-env  lib/type-env
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type 'int?}))
+        form (f/ast->form ast)
+        _ (is (= form '(do (println "Hello world!") 0)))
+        func (eval `(fn [] ~form))]
+    (let [s (new StringWriter)]
+      (binding [*out* s]
+        (is (= (func) 0))
+        (is (= (str s) "Hello world!\n"))))))
 
 (deftest replace-space-with-newline-test
-  (let [push [[:lit \newline]
-              [:lit \space]
-              [:var 0]
-              [:var `lib/replace-char]
-              :apply
-              :let
-              ;; From here below is the body of the `let`.
-              ;; Do part 2
-              [:lit \newline]
-              [:var 1]
-              [:var `lib/remove-char]
-              :apply
-              [:var 'length]
-              :apply
-              ;; Do part 1
-              [:var 1]
-              [:var 'println]
-              :apply
-              ;; Do
-              [:var 'do2]
-              :apply]
-        func (c/synth-fn
-               ['input1]
-               (c/push->clj {:push        (pl/plushy->push push)
-                             :arg-symbols ['input1]
-                             :return-type int?
-                             :type-env    (->> lib/library
-                                               (merge {'input1 string?})
-                                               (mapv (fn [[symb typ]] [:= symb typ])))
-                             :dealiases   lib/dealiases}))]
-    (is (= "Hello\nworld!\n"
-           (with-out-str
-             (is (= 11 (func "Hello world!"))))))))
+  (let [{::c/keys [ast type]} (c/push->ast {:push      [{:gene :lit :val \newline :type {:type 'char?}}
+                                                        {:gene :lit :val \space :type {:type 'char?}}
+                                                        {:gene :local :idx 0}
+                                                        {:gene :var :name `lib/replace-char}
+                                                        {:gene :apply}
+                                                        {:gene :let}
+                                                        [;; This vector contains the body of the `let`
+                                                         ;; Starting with the second clause of the `do`
+                                                         {:gene :lit :val \newline :type {:type 'char?}}
+                                                         {:gene :local :idx 1}
+                                                         {:gene :var :name `lib/remove-char}
+                                                         {:gene :apply}
+                                                         {:gene :var :name 'length}
+                                                         {:gene :apply}
+                                                         ;; Followed by the first clause of the `do`
+                                                         {:gene :local :idx 1}
+                                                         {:gene :var :name 'println}
+                                                         {:gene :apply}
+                                                         ;; Invoke the do
+                                                         {:gene :var :name 'do2}
+                                                         {:gene :apply}]]
+                                            :locals    ['in1]
+                                            :ret-type  {:type 'int?}
+                                            :type-env  (assoc lib/type-env
+                                                         'in1 {:type 'string?})
+                                            :dealiases lib/dealiases})
+        _ (is (= type {:type 'int?}))
+        form (f/ast->form ast)
+        _ (is (matches? (let [?v (erp12.cbgp-lite.lang.lib/replace-char in1 \space \newline)]
+                          (do (println ?v)
+                              (count (erp12.cbgp-lite.lang.lib/remove-char ?v \newline))))
+                        form))
+        func (eval `(fn [~'in1] ~form))]
+    (let [s (new StringWriter)]
+      (binding [*out* s]
+        (is (= (func "a b c") 3))
+        (is (= (str s) "a\nb\nc\n"))))))

--- a/test/erp12/cbgp_lite/lang/form_test.clj
+++ b/test/erp12/cbgp_lite/lang/form_test.clj
@@ -1,0 +1,34 @@
+(ns erp12.cbgp-lite.lang.form-test
+  (:require [clojure.test :refer [deftest is]]
+            [erp12.cbgp-lite.lang.form :as form]))
+
+(deftest ast->form-test
+  ;(is (= (form/ast->form {:op   :invoke
+  ;                        :fn   {:op :var :var '+}
+  ;                        :args [{:op :const :val 100}
+  ;                               {:op :local :name 'x}]})
+  ;       '(+ 100 x)))
+  ;(is (= (form/ast->form {:op       :let
+  ;                        :bindings [{:op   :binding
+  ;                                    :name 'f
+  ;                                    :init {:op      :fn
+  ;                                           :methods [{:op     :fn-method
+  ;                                                      :params [{:op :binding :name 'a}]
+  ;                                                      :body   {:op :local :name 'a}}]}}]
+  ;                        :body     {:op   :invoke
+  ;                                   :fn   {:op :local :name 'f}
+  ;                                   :args [{:op :const :val "!"}]}})
+  ;       '(let [f (fn [a] a)]
+  ;          (f "!"))))
+  (is (= (form/ast->form {:op   :invoke
+                          :fn   {:op :var :var 'mapv}
+                          :args [{:op      :fn
+                                  :methods [{:op     :fn-method
+                                             :params [{:op :binding :name 'a}]
+                                             :body   {:op   :invoke
+                                                      :fn   {:op :var :var 'inc}
+                                                      :args [{:op :local :name 'a}]}}]}
+                                 {:op :const :val [1 2 3]}]})
+         '(mapv (fn [a] (inc a)) [1 2 3])))
+
+  )

--- a/test/erp12/cbgp_lite/lang/schema_test.clj
+++ b/test/erp12/cbgp_lite/lang/schema_test.clj
@@ -1,0 +1,17 @@
+(ns erp12.cbgp-lite.lang.schema-test
+  (:require [clojure.test :refer :all]
+            [erp12.cbgp-lite.lang.schema :as sch]))
+
+(deftest occurs?-test
+  (is (sch/occurs? 'a {:op :local :name 'a}))
+  (is (sch/occurs? {:type :s-var :sym 'A}
+                   {:type   :=>
+                    :input  {:type     :cat
+                             :children [{:type :s-var :sym 'A}]}
+                    :output {:type 'int?}}))
+  (is (not (sch/occurs? 'x {:op :var :var '+})))
+  (is (not (sch/occurs? {:type :s-var :sym 'A}
+                        {:type   :=>
+                         :input  {:type     :cat
+                                  :children [{:type :s-var :sym 'B}]}
+                         :output {:type 'int?}}))))


### PR DESCRIPTION
- ASTs are now meet a minimal version of Clojure's official AST spec from [tools.analyzer](https://github.com/clojure/tools.analyzer).
- Type (schema) system has been rewritten with many bug fixes. See [schema-inference](https://github.com/erp12/schema-inference).
- Overall cost of program compilation dramatically reduced.
- Added hand-written solution genomes to some PSB problems as a form of end-to-end test for program compilation.