### PR TITLE
Bump ga-clj and switch to pre- post- evaluator hooks.

### DIFF
--- a/benchmarks/erp12/cbgp_lite/benchmark/hill_climbing.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/hill_climbing.clj
@@ -37,9 +37,9 @@
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-full-behavior))
         opts (merge config task)
-        individual-factory (i/make-individual-factory (-> opts
-                                                          (assoc :cases (:train task))
-                                                          (dissoc :train :test)))
+        individual-factory (i/make-evaluator (-> opts
+                                                 (assoc :cases (:train task))
+                                                 (dissoc :train :test)))
         {:keys [individual result]} (hc/run {;; Function for generating random genomes.
                                              :genome-factory       #(pl/random-plushy-genome opts)
                                              ;; Function for converting genomes into compiled Clojure functions

--- a/benchmarks/erp12/cbgp_lite/benchmark/random_search.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/random_search.clj
@@ -32,9 +32,9 @@
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-until-first-failure))
         opts (merge config task)
-        individual-factory (i/make-individual-factory (-> opts
-                                                          (assoc :cases (:train task))
-                                                          (dissoc :train :test)))
+        individual-factory (i/make-evaluator (-> opts
+                                                 (assoc :cases (:train task))
+                                                 (dissoc :train :test)))
         {:keys [individual result]} (rs/run {;; Function for generating random genomes.
                                              :genome-factory     #(pl/random-plushy-genome opts)
                                              ;; Function for converting genomes into compiled Clojure functions

--- a/benchmarks/erp12/cbgp_lite/benchmark/simulated_annealing.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/simulated_annealing.clj
@@ -36,9 +36,9 @@
                  task/enhance-task
                  (assoc :evaluate-fn i/evaluate-full-behavior))
         opts (merge config task)
-        individual-factory (i/make-individual-factory (-> opts
-                                                          (assoc :cases (:train task))
-                                                          (dissoc :train :test)))
+        individual-factory (i/make-evaluator (-> opts
+                                                 (assoc :cases (:train task))
+                                                 (dissoc :train :test)))
         {:keys [best result]} (sa/run {;; Function for generating random genomes.
                                        :genome-factory     #(pl/random-plushy-genome opts)
                                        ;; Function for converting genomes into compiled Clojure functions

--- a/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
@@ -253,47 +253,47 @@
    ; "super-anagrams"
 
    "syllables"
-   {:input->type    {'input1 {:type 'string?}}
-    :ret-type       {:type 'string?}
-    :other-types    [{:type 'int?} {:type 'boolean?} {:type 'char?}]
+   {:input->type {'input1 {:type 'string?}}
+    :ret-type    {:type 'string?}
+    :other-types [{:type 'int?} {:type 'boolean?} {:type 'char?}]
 
-    :extra-genes    [{:gene :lit, :val "The number of syllables is ", :type {:type 'string?}}
-                     {:gene :lit, :val \a, :type {:type 'char?}}
-                     {:gene :lit, :val \e, :type {:type 'char?}}
-                     {:gene :lit, :val \i, :type {:type 'char?}}
-                     {:gene :lit, :val \o, :type {:type 'char?}}
-                     {:gene :lit, :val \u, :type {:type 'char?}}
-                     {:gene :lit, :val \y, :type {:type 'char?}}
-                     {:gene :lit, :val "aeiouy", :type {:type 'string?}}
-                     {:gene :lit-generator, :fn bu/rand-char, :type {:type 'char?}}]
-    :loss-fns       [lev/distance
-                     (let [parse #(try (Integer/parseInt (last (str/split % #"\s+")))
-                                       (catch Exception e nil))]
-                       #(if-let [num (parse %1)]
-                          (bu/absolute-distance num (parse %2))
-                          penalty))]}
+    :extra-genes [{:gene :lit, :val "The number of syllables is ", :type {:type 'string?}}
+                  {:gene :lit, :val \a, :type {:type 'char?}}
+                  {:gene :lit, :val \e, :type {:type 'char?}}
+                  {:gene :lit, :val \i, :type {:type 'char?}}
+                  {:gene :lit, :val \o, :type {:type 'char?}}
+                  {:gene :lit, :val \u, :type {:type 'char?}}
+                  {:gene :lit, :val \y, :type {:type 'char?}}
+                  {:gene :lit, :val "aeiouy", :type {:type 'string?}}
+                  {:gene :lit-generator, :fn bu/rand-char, :type {:type 'char?}}]
+    :loss-fns    [lev/distance
+                  (let [parse #(try (Integer/parseInt (last (str/split % #"\s+")))
+                                    (catch Exception e nil))]
+                    #(if-let [num (parse %1)]
+                       (bu/absolute-distance num (parse %2))
+                       penalty))]}
 
    "vector-average"
-   {:input->type    {'input1 {:type :vector :child {:type 'double?}}}
-    :ret-type       {:type 'double?}
-    :other-types    [{:type 'int?}]
-    :loss-fns       [#(bu/round 4 (bu/absolute-distance %1 %2))]}
+   {:input->type {'input1 {:type :vector :child {:type 'double?}}}
+    :ret-type    {:type 'double?}
+    :other-types [{:type 'int?}]
+    :loss-fns    [#(bu/round 4 (bu/absolute-distance %1 %2))]}
 
    "vectors-summed"
-   {:input->type    {'input1 {:type :vector :child {:type 'int?}}
-                     'input2 {:type :vector :child {:type 'int?}}}
-    :ret-type       {:type :vector :child {:type 'int?}}
-    :other-types    [{:type 'int?}]
-    :loss-fns       [(fn [y-hat y]
-                       (reduce + (map #(or (bu/absolute-distance %1 %2) penalty)
-                                      y-hat y)))
-                     (fn [y-hat y]
-                       (* 1000 (bu/absolute-distance (count y-hat) (count y))))]
-    :solution       (list {:gene :local :idx 0}
-                          {:gene :local :idx 1}
-                          {:gene :var :name 'int-add}
-                          {:gene :var :name 'mapv2}
-                          {:gene :apply})}
+   {:input->type {'input1 {:type :vector :child {:type 'int?}}
+                  'input2 {:type :vector :child {:type 'int?}}}
+    :ret-type    {:type :vector :child {:type 'int?}}
+    :other-types [{:type 'int?}]
+    :loss-fns    [(fn [y-hat y]
+                    (reduce + (map #(or (bu/absolute-distance %1 %2) penalty)
+                                   y-hat y)))
+                  (fn [y-hat y]
+                    (* 1000 (bu/absolute-distance (count y-hat) (count y))))]
+    :solution    (list {:gene :local :idx 0}
+                       {:gene :local :idx 1}
+                       {:gene :var :name 'int-add}
+                       {:gene :var :name 'mapv2}
+                       {:gene :apply})}
 
    ; "wallis-pi"
    ; "word-stats"
@@ -325,13 +325,13 @@
   (let [suite (problems {:penalty 1000})]
     (doseq [[problem-name task] (filter (fn [[_ task]] (contains? task :solution)) suite)]
       (println "Starting" problem-name)
-      (let [factory (i/make-individual-factory (-> task
-                                                   task/enhance-task
-                                                   (assoc :evaluate-fn i/evaluate-full-behavior
-                                                          :cases (:test (read-cases {:data-dir (name data-dir)
-                                                                                     :problem  problem-name
-                                                                                     :n-test   num-cases
-                                                                                     :n-train  0})))))
+      (let [factory (i/make-evaluator (-> task
+                                          task/enhance-task
+                                          (assoc :evaluate-fn i/evaluate-full-behavior
+                                                 :cases (:test (read-cases {:data-dir (name data-dir)
+                                                                            :problem  problem-name
+                                                                            :n-test   num-cases
+                                                                            :n-train  0})))))
             start-time (System/currentTimeMillis)
             evaluation (factory (:solution task) nil)
             duration (/ (- (System/currentTimeMillis) start-time) 1000)]
@@ -350,4 +350,4 @@
 
   (validate-solutions {:data-dir "data/psb/" :num-cases 10})
 
-  )
+)

--- a/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
@@ -245,7 +245,7 @@
    "string-lengths-backwards"
    {:input->type {'input1 {:type :vector :child {:type 'string?}}}
     :ret-type    {:type 'string?}
-    :other-types [{:type 'string?} {:type 'int?} {:type 'boolean?} {:type :vector :child {:type 'string?}}]
+    :other-types [{:type 'int?} {:type 'boolean?}]
     :extra-genes [{:gene :lit-generator, :fn (bu/int-generator 100), :type {:type 'int?}}]
     :loss-fns    [lev/distance]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps    {org.clojure/core.match           {:mvn/version "1.0.0"}
            com.taoensso/timbre              {:mvn/version "5.1.2"}
            io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
-           io.github.erp12/ga-clj           {:git/sha "4d5789f751a8c7ea5edde2f1a0e319221545fb56"}
+           io.github.erp12/ga-clj           {:git/sha "763c0b5e9febfb9e8e5d79ac3e3afb7104d10b36"}
            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
  :aliases {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}}
                         :ns-default build}

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -305,7 +305,7 @@
    'int-add             (binary-transform {:type 'int?})
    'int-sub             (binary-transform {:type 'int?})
    'int-mult            (binary-transform {:type 'int?})
-   'int-div             (simple-fn-schema [{:type 'int?} {:type 'int?}] {:type 'double})
+   'int-div             (simple-fn-schema [{:type 'int?} {:type 'int?}] {:type 'double?})
    'int-mod             (binary-transform {:type 'int?})
    'int-inc             (unary-transform {:type 'int?})
    'int-dec             (unary-transform {:type 'int?})

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -117,7 +117,7 @@
        :cases-used  (count cases)
        :exception   (:output (first (filter #(instance? Exception (:output %)) behavior)))})))
 
-(defn make-individual-factory
+(defn make-evaluator
   [{:keys [evaluate-fn cases arg-symbols] :as opts}]
   (fn [gn context]
     ;(log/debug "Genome" gn)

--- a/test/erp12/cbgp_lite/search/individual_test.clj
+++ b/test/erp12/cbgp_lite/search/individual_test.clj
@@ -67,19 +67,19 @@
             :total-error 5
             :exception   nil}))))
 
-(deftest individual-factory-test
-  (let [factory (i/make-individual-factory (-> {:input->type {'input1 {:type 'double?}
-                                                              'input2 {:type 'int?}}
-                                                :ret-type    {:type 'double?}
-                                                :loss-fns    [absolute-dist]
-                                                :penalty     1000
-                                                :evaluate-fn i/evaluate-full-behavior}
-                                               (u/enhance :arg-symbols task/arg-symbols
-                                                          :type-env task/type-environment)))]
-    (is (= (dissoc (factory (list {:gene :lit
-                                   :val 1.0
-                                   :type {:type 'double?}})
-                            {:cases [{:inputs [1.5 2] :output 3.5}]})
+(deftest make-evaluator-test
+  (let [evaluator (i/make-evaluator (-> {:input->type {'input1 {:type 'double?}
+                                                       'input2 {:type 'int?}}
+                                         :ret-type    {:type 'double?}
+                                         :loss-fns    [absolute-dist]
+                                         :penalty     1000
+                                         :evaluate-fn i/evaluate-full-behavior}
+                                        (u/enhance :arg-symbols task/arg-symbols
+                                                   :type-env task/type-environment)))]
+    (is (= (dissoc (evaluator (list {:gene :lit
+                                     :val  1.0
+                                     :type {:type 'double?}})
+                              {:cases [{:inputs [1.5 2] :output 3.5}]})
                    :func)
            {:behavior    '({:output 1.0 :std-out ""})
             :code        1.0
@@ -112,15 +112,15 @@
                          :individual {:genome      [10 10 10 10]
                                       :total-error (+ 30 4)})))))
   (testing "number-io"
-    (let [factory (i/make-individual-factory (-> {:input->type {'input1 {:type 'double?}
-                                                                'input2 {:type 'int?}}
-                                                  :ret-type    {:type 'double?}
-                                                  :vars        #{'double 'double-add}
-                                                  :loss-fns    [absolute-dist]
-                                                  :penalty     1000
-                                                  :evaluate-fn i/evaluate-full-behavior}
-                                                 (u/enhance :arg-symbols task/arg-symbols
-                                                            :type-env task/type-environment)))
+    (let [factory (i/make-evaluator (-> {:input->type {'input1 {:type 'double?}
+                                                       'input2 {:type 'int?}}
+                                         :ret-type    {:type 'double?}
+                                         :vars        #{'double 'double-add}
+                                         :loss-fns    [absolute-dist]
+                                         :penalty     1000
+                                         :evaluate-fn i/evaluate-full-behavior}
+                                        (u/enhance :arg-symbols task/arg-symbols
+                                                   :type-env task/type-environment)))
           cases [{:inputs [1.5 2] :output 3.5}
                  {:inputs [0.0 0] :output 0.0}
                  {:inputs [-1.0 1] :output 0.0}]]


### PR DESCRIPTION
Bumps [`ga-clj`](https://github.com/erp12/ga-clj) and switches to the new pre- and post- evaluation hooks for performing things like downsampling training cases, computing epsilon, and grouping the population by error vector for lexicase selection. 

Also includes minor fixes to a couple problems and functions.