### PR TITLE
Adds string functions and type counter log file

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:path    ["src"]
  :deps    {org.clojure/core.match           {:mvn/version "1.0.0"}
-           com.taoensso/timbre              {:mvn/version "5.1.2"}
+           com.taoensso/timbre              {:mvn/version "6.0.4"}
            io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
            io.github.erp12/ga-clj           {:git/sha "763c0b5e9febfb9e8e5d79ac3e3afb7104d10b36"}
            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -11,13 +11,21 @@ def run_cmd(opts: argparse.Namespace, run_id: int) -> str:
     log_file = os.path.join(log_dir, f"run{run_id}.txt")
     main_ns = "erp12.cbgp-lite.benchmark." + opts.search
     suite_ns = "erp12.cbgp-lite.benchmark.suite.psb"
+    types_file = os.path.join(log_dir, f"run{run_id}_types.edn")
+    clj_cmd = " ".join([
+        f"{opts.clj} -X:benchmarks {main_ns}/run",
+        f":suite-ns {suite_ns}",
+        f":data-dir '\"{opts.data_dir}\"'",
+        f":problem '\"{opts.problem}\"'",
+        f":type-counts-file '\"{types_file}\"'" if opts.log_types else ""
+    ])
     return "; ".join(
         [
             f'echo "Starting run {run_id}"',
             "export PATH=$PATH:/usr/java/latest/bin",
             f"cd {opts.cbgp}",
             f"mkdir -p {log_dir}",
-            f"{opts.clj} -X:benchmarks {main_ns}/run :suite-ns {suite_ns} :data-dir '\"{opts.data_dir}\"' :problem '\"{opts.problem}\"' 2>&1 | tee {log_file}",
+            f"{clj_cmd} 2>&1 | tee {log_file}",
             f'echo "Finished Run {run_id}"',
         ]
     )
@@ -44,6 +52,10 @@ def cli_opts() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--out", help="The path to put the log files of the run captured from stdout."
+    )
+    parser.add_argument(
+        "--log-types", help="If set, an EDN file of type counts will be added to the log file dir.",
+        action='store_true',
     )
     parser.add_argument(
         "--clj",
@@ -85,7 +97,8 @@ python3 scripts/local_runner.py \
     --search "ga" \
     --problem "vectors-summed" \
     --data-dir "./data/psb/" \
-    --num-runs 3 \
+    --num-runs 2 \
     --out "./data/logs/test/" \
+    --log-types \
     --parallelism 1
 """

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -60,13 +60,13 @@
   [s sub]
   (<= 0 (.indexOf s sub)))
 
+(defn filter-str
+  [pred s]
+  (str/join (filter pred s)))
+
 (defn contains-char?
   [s c]
   (<= 0 (.indexOf s (str c))))
-
-(defn index-of-char
-  [s c]
-  (.indexOf s (str c)))
 
 (defn occurrences-of-char
   [s c]
@@ -208,6 +208,14 @@
 ;; Ground Schemas
 ;; nil? boolean? int? double? char? string? keyword?
 
+(def NIL {:type 'nil?})
+(def BOOLEAN {:type 'boolean?})
+(def INT {:type 'int?})
+(def DOUBLE {:type 'double?})
+(def CHAR {:type 'char?})
+(def STRING {:type 'string?})
+(def KEYWORD {:type 'keyword?})
+
 (defn unary-transform
   [type]
   {:type   :=>
@@ -232,7 +240,7 @@
    :input  {:type :cat :children [type type]}
    :output {:type 'boolean?}})
 
-(defn simple-fn-schema
+(defn simple-fn
   [args ret]
   {:type   :=>
    :input  {:type :cat :children (vec args)}
@@ -242,7 +250,7 @@
   [sym]
   {:type :s-var :sym sym})
 
-(defn vector-schema
+(defn vector-of
   [el]
   {:type :vector :child el})
 
@@ -251,219 +259,226 @@
    ;; Conditional Control Flow
    'if                  {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [{:type 'boolean?} (s-var 'a) (s-var 'a)]
-                                                   (s-var 'a))}
+                         :body   (simple-fn [BOOLEAN (s-var 'a) (s-var 'a)]
+                                            (s-var 'a))}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Higher Order Functions
    'mapv                {:type   :scheme
                          :s-vars ['a 'b]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a)] (s-var 'b))
-                                                    (vector-schema (s-var 'a))]
-                                                   (vector-schema (s-var 'b)))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a)] (s-var 'b))
+                                             (vector-of (s-var 'a))]
+                                            (vector-of (s-var 'b)))}
    'mapv2               {:type   :scheme
                          :s-vars ['a1 'a2 'b]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a1) (s-var 'a2)] (s-var 'b))
-                                                    (vector-schema (s-var 'a1))
-                                                    (vector-schema (s-var 'a2))]
-                                                   (vector-schema (s-var 'b)))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a1) (s-var 'a2)] (s-var 'b))
+                                             (vector-of (s-var 'a1))
+                                             (vector-of (s-var 'a2))]
+                                            (vector-of (s-var 'b)))}
    'filterv             {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a)] {:type 'boolean?})
-                                                    (vector-schema (s-var 'a))]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a)] BOOLEAN)
+                                             (vector-of (s-var 'a))]
+                                            (vector-of (s-var 'a)))}
    `removev             {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a)] {:type 'boolean?})
-                                                    (vector-schema (s-var 'a))]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a)] BOOLEAN)
+                                             (vector-of (s-var 'a))]
+                                            (vector-of (s-var 'a)))}
    `mapcatv             {:type   :scheme
                          :s-vars ['a 'b]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a)] (vector-schema (s-var 'b)))
-                                                    (vector-schema (s-var 'a))]
-                                                   (vector-schema (s-var 'b)))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a)] (vector-of (s-var 'b)))
+                                             (vector-of (s-var 'a))]
+                                            (vector-of (s-var 'b)))}
    'reduce              {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'a) (s-var 'a)] (s-var 'a))
-                                                    (vector-schema (s-var 'a))]
-                                                   (s-var 'a))}
+                         :body   (simple-fn [(simple-fn [(s-var 'a) (s-var 'a)] (s-var 'a))
+                                             (vector-of (s-var 'a))]
+                                            (s-var 'a))}
    'fold                {:type   :scheme
                          :s-vars ['a 'b]
-                         :body   (simple-fn-schema [(simple-fn-schema [(s-var 'b) (s-var 'a)] (s-var 'b))
-                                                    (s-var 'b)
-                                                    (vector-schema (s-var 'a))]
-                                                   (s-var 'b))}
+                         :body   (simple-fn [(simple-fn [(s-var 'b) (s-var 'a)] (s-var 'b))
+                                             (s-var 'b)
+                                             (vector-of (s-var 'a))]
+                                            (s-var 'b))}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Common
    '=                   {:type   :scheme
                          :s-vars ['a 'b]
-                         :body   (simple-fn-schema [(s-var 'a) (s-var 'b)] {:type 'boolean?})}
+                         :body   (simple-fn [(s-var 'a) (s-var 'b)] BOOLEAN)}
    'not=                {:type   :scheme
                          :s-vars ['a 'b]
-                         :body   (simple-fn-schema [(s-var 'a) (s-var 'b)] {:type 'boolean?})}
+                         :body   (simple-fn [(s-var 'a) (s-var 'b)] BOOLEAN)}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Numeric
-   'int-add             (binary-transform {:type 'int?})
-   'int-sub             (binary-transform {:type 'int?})
-   'int-mult            (binary-transform {:type 'int?})
-   'int-div             (simple-fn-schema [{:type 'int?} {:type 'int?}] {:type 'double?})
-   'int-mod             (binary-transform {:type 'int?})
-   'int-inc             (unary-transform {:type 'int?})
-   'int-dec             (unary-transform {:type 'int?})
-   'int-lt              (binary-pred {:type 'int?})
-   'int-gt              (binary-pred {:type 'int?})
-   'int-le              (binary-pred {:type 'int?})
-   'int-ge              (binary-pred {:type 'int?})
-   'double-add          (binary-transform {:type 'double?})
-   'double-sub          (binary-transform {:type 'double?})
-   'double-mult         (binary-transform {:type 'double?})
-   'double-div          (binary-transform {:type 'double?})
-   'double-mod          (binary-transform {:type 'double?})
-   'double-inc          (unary-transform {:type 'double?})
-   'double-dec          (unary-transform {:type 'double?})
-   'double-lt           (binary-pred {:type 'double?})
-   'double-gt           (binary-pred {:type 'double?})
-   'double-le           (binary-pred {:type 'double?})
-   'double-ge           (binary-pred {:type 'double?})
-   'int                 (simple-fn-schema [{:type 'double?}] {:type 'int?})
-   'double              (simple-fn-schema [{:type 'int?}] {:type 'double?})
-   'char->int           (simple-fn-schema [{:type 'char?}] {:type 'int?})
-   'min-int             (binary-transform {:type 'int?})
-   'min-double          (binary-transform {:type 'double?})
-   'max-int             (binary-transform {:type 'int?})
-   'max-double          (binary-transform {:type 'double?})
-   `sin                 (unary-transform {:type 'double?})
-   `cos                 (unary-transform {:type 'double?})
-   `tan                 (unary-transform {:type 'double?})
+   'int-add             (binary-transform INT)
+   'int-sub             (binary-transform INT)
+   'int-mult            (binary-transform INT)
+   'int-div             (simple-fn [INT INT] DOUBLE)
+   'int-mod             (binary-transform INT)
+   'int-inc             (unary-transform INT)
+   'int-dec             (unary-transform INT)
+   'int-lt              (binary-pred INT)
+   'int-gt              (binary-pred INT)
+   'int-le              (binary-pred INT)
+   'int-ge              (binary-pred INT)
+   'double-add          (binary-transform DOUBLE)
+   'double-sub          (binary-transform DOUBLE)
+   'double-mult         (binary-transform DOUBLE)
+   'double-div          (binary-transform DOUBLE)
+   'double-mod          (binary-transform DOUBLE)
+   'double-inc          (unary-transform DOUBLE)
+   'double-dec          (unary-transform DOUBLE)
+   'double-lt           (binary-pred DOUBLE)
+   'double-gt           (binary-pred DOUBLE)
+   'double-le           (binary-pred DOUBLE)
+   'double-ge           (binary-pred DOUBLE)
+   'int                 (simple-fn [DOUBLE] INT)
+   'double              (simple-fn [INT] DOUBLE)
+   'char->int           (simple-fn [CHAR] INT)
+   'min-int             (binary-transform INT)
+   'min-double          (binary-transform DOUBLE)
+   'max-int             (binary-transform INT)
+   'max-double          (binary-transform DOUBLE)
+   `sin                 (unary-transform DOUBLE)
+   `cos                 (unary-transform DOUBLE)
+   `tan                 (unary-transform DOUBLE)
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Text
    'str                 {:type   :scheme
                          :s-vars ['t]
-                         :body   (simple-fn-schema [(s-var 't)] {:type 'string?})}
-   `int->char           (simple-fn-schema [{:type 'int?}] {:type 'char?})
-   `whitespace?         (unary-pred {:type 'char?})
-   `digit?              (unary-pred {:type 'char?})
-   `letter?             (unary-pred {:type 'char?})
-   `string-concat       (simple-fn-schema [{:type 'string?} {:type 'string?}] {:type 'string?})
-   `append-str          (simple-fn-schema [{:type 'string?} {:type 'char?}] {:type 'string?})
-   `take-str            (simple-fn-schema [{:type 'int?} {:type 'string?}] {:type 'string?})
-   `safe-subs           (simple-fn-schema [{:type 'string?} {:type 'int?} {:type 'int?}] {:type 'string?})
-   'first-str           (simple-fn-schema [{:type 'string?}] {:type 'char?})
-   'last-str            (simple-fn-schema [{:type 'string?}] {:type 'char?})
-   `rest-str            (unary-transform {:type 'string?})
-   `butlast-str         (unary-transform {:type 'string?})
-   'nth-str             (simple-fn-schema [{:type 'string?} {:type 'int?}] {:type 'char?})
-   'length              (simple-fn-schema [{:type 'string?}] {:type 'int?})
-   `str/reverse         (unary-transform {:type 'string?})
-   'string->chars       (simple-fn-schema [{:type 'sing?}] (vector-schema {:type 'char?}))
-   `split-str           (simple-fn-schema [{:type 'strtring?} {:type 'string?}] (vector-schema {:type 'string?}))
-   `split-str-on-char   (simple-fn-schema [{:type 'string?} {:type 'char?}] (vector-schema {:type 'string?}))
-   `split-str-on-ws     (simple-fn-schema [{:type 'string?}] (vector-schema {:type 'string?}))
-   'empty-str?          (unary-pred {:type 'string?})
-   `substring?          (binary-pred {:type 'string?})
-   `contains-char?      (simple-fn-schema [{:type 'string?} {:type 'char?}] {:type 'boolean?})
-   `index-of-char       (simple-fn-schema [{:type 'string?} {:type 'char?}] {:type 'int?})
-   `occurrences-of-char (simple-fn-schema [{:type 'string?} {:type 'char?}] {:type 'int?})
-   `str/replace         (simple-fn-schema [{:type 'string?} {:type 'string?} {:type 'string?}] {:type 'string?})
-   `str/replace-first   (simple-fn-schema [{:type 'string?} {:type 'string?} {:type 'string?}] {:type 'string?})
-   `replace-char        (simple-fn-schema [{:type 'string?} {:type 'char?} {:type 'char?}] {:type 'string?})
-   `replace-first-char  (simple-fn-schema [{:type 'string?} {:type 'char?} {:type 'char?}] {:type 'string?})
-   `remove-char         (simple-fn-schema [{:type 'string?} {:type 'char?}] {:type 'string?})
-   `set-char            (simple-fn-schema [{:type 'string?} {:type 'int?} {:type 'char?}] {:type 'string?})
+                         :body   (simple-fn [(s-var 't)] STRING)}
+   `int->char           (simple-fn [INT] CHAR)
+   `whitespace?         (unary-pred CHAR)
+   `digit?              (unary-pred CHAR)
+   `letter?             (unary-pred CHAR)
+   `string-concat       (simple-fn [STRING STRING] STRING)
+   `append-str          (simple-fn [STRING CHAR] STRING)
+   `take-str            (simple-fn [INT STRING] STRING)
+   `safe-subs           (simple-fn [STRING INT INT] STRING)
+   `filter-str          (simple-fn [(simple-fn [CHAR] BOOLEAN) STRING] STRING)
+   'first-str           (simple-fn [STRING] CHAR)
+   'last-str            (simple-fn [STRING] CHAR)
+   `rest-str            (unary-transform STRING)
+   `butlast-str         (unary-transform STRING)
+   'nth-str             (simple-fn [STRING INT] CHAR)
+   'length              (simple-fn [STRING] INT)
+   'map-str             {:type   :scheme
+                         :s-vars ['a]
+                         :body   (simple-fn [(simple-fn [CHAR] (s-var 'a))
+                                             STRING]
+                                            (vector-of (s-var 'a)))}
+   `str/reverse         (unary-transform STRING)
+   'string->chars       (simple-fn [STRING] (vector-of CHAR))
+   `split-str           (simple-fn [STRING STRING] (vector-of STRING))
+   `split-str-on-char   (simple-fn [STRING CHAR] (vector-of STRING))
+   `split-str-on-ws     (simple-fn [STRING] (vector-of STRING))
+   'empty-str?          (unary-pred STRING)
+   `substring?          (binary-pred STRING)
+   `contains-char?      (simple-fn [STRING CHAR] BOOLEAN)
+   'index-of-char       (simple-fn [STRING CHAR] INT)
+   'index-of-str        (simple-fn [STRING STRING] INT)
+   `occurrences-of-char (simple-fn [STRING CHAR] INT)
+   `str/replace         (simple-fn [STRING STRING STRING] STRING)
+   `str/replace-first   (simple-fn [STRING STRING STRING] STRING)
+   `replace-char        (simple-fn [STRING CHAR CHAR] STRING)
+   `replace-first-char  (simple-fn [STRING CHAR CHAR] STRING)
+   `remove-char         (simple-fn [STRING CHAR] STRING)
+   `set-char            (simple-fn [STRING INT CHAR] STRING)
    `str/join            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] {:type 'string?})}
+                         :body   (simple-fn [(vector-of (s-var 'a))] STRING)}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Boolean
-   `and                 (binary-transform {:type 'boolean?})
-   `or                  (binary-transform {:type 'boolean?})
-   'not                 (unary-transform {:type 'boolean?})
-   'zero-int?           (simple-fn-schema [{:type 'int?}] {:type 'boolean?})
-   'zero-double?        (simple-fn-schema [{:type 'double}] {:type 'boolean?})
+   `and                 (binary-transform BOOLEAN)
+   `or                  (binary-transform BOOLEAN)
+   'not                 (unary-transform BOOLEAN)
+   'zero-int?           (simple-fn [INT] BOOLEAN)
+   'zero-double?        (simple-fn [DOUBLE] BOOLEAN)
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Vector
    `concatv             {:type   :scheme
                          :s-vars ['a]
-                         :body   (binary-transform (vector-schema (s-var 'a)))}
+                         :body   (binary-transform (vector-of (s-var 'a)))}
    'conj                {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) (s-var 'a)] (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a)) (s-var 'a)] (vector-of (s-var 'a)))}
    `takev               {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [{:type 'int?} (vector-schema (s-var 'a))]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [INT (vector-of (s-var 'a))]
+                                            (vector-of (s-var 'a)))}
    `safe-subvec         {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) {:type 'int?} {:type 'int?}]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a)) INT INT]
+                                            (vector-of (s-var 'a)))}
    'first               {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] (s-var 'a))}
+                         :body   (simple-fn [(vector-of (s-var 'a))] (s-var 'a))}
    'last                {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] (s-var 'a))}
+                         :body   (simple-fn [(vector-of (s-var 'a))] (s-var 'a))}
    `restv               {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))] (vector-of (s-var 'a)))}
    `butlastv            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))] (vector-of (s-var 'a)))}
    `safe-nth            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) {:type 'int?}] (s-var 'a))}
+                         :body   (simple-fn [(vector-of (s-var 'a)) INT] (s-var 'a))}
    'count               {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] {:type 'int?})}
+                         :body   (simple-fn [(vector-of (s-var 'a))] INT)}
    `reversev            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))] (vector-of (s-var 'a)))}
    'empty?              {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))] {:type 'boolean?})}
+                         :body   (simple-fn [(vector-of (s-var 'a))] BOOLEAN)}
    `in?                 {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) (s-var 'a)] {:type 'boolean?})}
+                         :body   (simple-fn [(vector-of (s-var 'a)) (s-var 'a)] BOOLEAN)}
    `index-of            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) (s-var 'a)] {:type 'int?})}
+                         :body   (simple-fn [(vector-of (s-var 'a)) (s-var 'a)] INT)}
    `occurrences-of      {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) (s-var 'a)] {:type 'int?})}
+                         :body   (simple-fn [(vector-of (s-var 'a)) (s-var 'a)] INT)}
    `safe-assoc          {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))
-                                                    {:type 'int?}
-                                                    (s-var 'a)]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))
+                                             INT
+                                             (s-var 'a)]
+                                            (vector-of (s-var 'a)))}
    `replacev            {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))
-                                                    (s-var 'a)
-                                                    (s-var 'a)]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))
+                                             (s-var 'a)
+                                             (s-var 'a)]
+                                            (vector-of (s-var 'a)))}
    `replacev-first      {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a))
-                                                    (s-var 'a)
-                                                    (s-var 'a)]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a))
+                                             (s-var 'a)
+                                             (s-var 'a)]
+                                            (vector-of (s-var 'a)))}
    `remove-element      {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(vector-schema (s-var 'a)) (s-var 'a)]
-                                                   (vector-schema (s-var 'a)))}
+                         :body   (simple-fn [(vector-of (s-var 'a)) (s-var 'a)]
+                                            (vector-of (s-var 'a)))}
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;; Printing & Side Effects
    'do2                 {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [{:type 'nil?} (s-var 'a)] (s-var 'a))}
+                         :body   (simple-fn [NIL (s-var 'a)] (s-var 'a))}
    'do3                 {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [{:type 'nil?} {:type 'nil?} (s-var 'a)] (s-var 'a))}
+                         :body   (simple-fn [NIL NIL (s-var 'a)] (s-var 'a))}
    'print               {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(s-var 'a)] {:type 'nil?})}
+                         :body   (simple-fn [(s-var 'a)] NIL)}
    'println             {:type   :scheme
                          :s-vars ['a]
-                         :body   (simple-fn-schema [(s-var 'a)] {:type 'nil?})}
+                         :body   (simple-fn [(s-var 'a)] NIL)}
    })
 
 (def dealiases
@@ -484,6 +499,8 @@
     double-mult   *
     double-sub    -
     fold          reduce
+    index-of-char clojure.string/index-of
+    index-of-str  clojure.string/index-of
     int-add       +
     int-dec       dec
     int-div       erp12.cbgp-lite.lang.lib/safe-div
@@ -497,6 +514,7 @@
     int-sub       -
     last-str      last
     length        count
+    map-str       mapv
     mapv2         map
     max-double    max
     max-int       max

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -1,5 +1,5 @@
 (ns erp12.cbgp-lite.lang.lib
-  (:refer-clojure :exclude [and or])
+  (:refer-clojure :exclude [and or vector-of])
   (:require [clojure.core :as core]
             [clojure.string :as str]
             [erp12.cbgp-lite.lang.schema :as schema]))

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -147,14 +147,11 @@
 
 (defn simplify
   [{:keys [individual simplification-steps individual-factory context]}]
-  (log/info "PRE-SIMPLIFICATION" individual)
-  (let [simplified (reduce (fn [{:keys [genome total-error] :as best} _]
-                             (let [new-gn (vec (random-sample (rand) genome))
-                                   new-indiv (assoc (individual-factory new-gn context) :genome new-gn)]
-                               (if (<= (:total-error new-indiv) total-error)
-                                 new-indiv
-                                 best)))
-                           individual
-                           (range simplification-steps))]
-    (log/info "POST-SIMPLIFICATION" simplified)
-    simplified))
+  (reduce (fn [{:keys [genome total-error] :as best} _]
+            (let [new-gn (vec (random-sample (rand) genome))
+                  new-indiv (assoc (individual-factory new-gn context) :genome new-gn)]
+              (if (<= (:total-error new-indiv) total-error)
+                new-indiv
+                best)))
+          individual
+          (range simplification-steps)))

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -120,21 +120,21 @@
 (defn make-evaluator
   [{:keys [evaluate-fn cases arg-symbols] :as opts}]
   (fn [gn context]
-    ;(log/debug "Genome" gn)
+    (log/debug "Evaluating genome" gn)
     (let [cases (or (:cases context) cases)
-          ;_ (log/debug "Evaluating on" (count cases) "cases")
+          _ (log/debug "Evaluating on" (count cases) "cases")
           ;; Get Push code from the genome.
           push (pl/plushy->push gn)
-          ;_ (log/debug "Push" push)
+          _ (log/debug "Push" push)
           ;; Compile the Push into a Clojure form that accepts and returns the
           ;; correct types.
           ast (::c/ast (c/push->ast (assoc opts
                                       :push push
                                       :locals arg-symbols)))
-          ;_ (log/debug "AST" ast)
+          _ (log/debug "AST" ast)
           form (when ast
                  (f/ast->form ast))
-          ;_ (log/debug "Form" form)
+          _ (log/debug "Form" form)
           func (when form
                  (f/form->fn (vec arg-symbols) form))
           evaluation (evaluate-fn (merge {:func func :cases cases} opts))]

--- a/test/erp12/cbgp_lite/lang/lib_test.clj
+++ b/test/erp12/cbgp_lite/lang/lib_test.clj
@@ -37,11 +37,11 @@
 (deftest substring?-test
   (is (l/substring? "abc" "b")))
 
+(deftest filter-str-test
+  (is (= "ac" (l/filter-str #(not= % \b) "abc"))))
+
 (deftest contains-char?-test
   (is (l/contains-char? "abc" \b)))
-
-(deftest index-of-char-test
-  (is (= 1 (l/index-of-char "abc" \b))))
 
 (deftest occurrences-of-char-test
   (is (= 1 (l/occurrences-of-char "abc" \b))))


### PR DESCRIPTION
b77b610 adds the string functions discussed previously.

ce9a612 Adds some `:trace` level logs for showing the AST compilation step-by-step. It's _very_ verbose and shouldn't be used during evolution but can be enabled as the REPL for easier development.

ffda380 Adds the ability to collect counts for each type seen throughout a run and write them to an EDN file at the end of a run. The EDN file contains a vector of maps containing 2 keys each: `:type` and `:freq`. To enable this, pass an additional option to the `run` function in `ga.clj`

```clojure
  (run {:suite-ns erp12.cbgp-lite.benchmark.suite.psb
        :data-dir "data/psb"
        :problem "vectors-summed"
        :type-counts-file "logs/vectors-summed/my-run/types2.edn"})
```

or at the command line when using `clj`

```sh
clj -X:benchmarks erp12.cbgp-lite.benchmark.ga/run \
  :suite-ns erp12.cbgp-lite.benchmark.suite.psb \
  :data-dir '"data/psb"' \
  :problem '"vectors-summed"' \
  :type-counts-file '"logs/vectors-summed/my-run/types2.edn"'
```

or add the `--log-types` flag to the python runner

```sh
python3 scripts/local_runner.py \
    --search "ga" \
    --problem "vectors-summed" \
    --data-dir "./data/psb/" \
    --num-runs 2 \
    --out "./data/logs/test/" \
    --log-types
    --parallelism 1
```