### PR TITLE
Adds :biggest-out and :newest-out strategy for picking the final AST

### DIFF
--- a/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
@@ -24,7 +24,14 @@
    :min-genome-size      50
    :max-genome-size      250
    :penalty              1e5
-   :simplification-steps 2000})
+   :simplification-steps 2000
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+   ;; Experimental
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+   ;; Supported -  nil, :biggest-out, :newest-out, or a function from state to unboxed AST.
+   ;; `nil` will search the stack for the top AST of a valid type.
+   :state-output-fn      nil
+   })
 
 (defn make-breed
   [opts]
@@ -148,8 +155,9 @@
 
 (comment
 
-  (run {:suite-ns 'erp12.cbgp-lite.benchmark.suite.psb
-        :data-dir "data/psb/"
-        :problem  "fuel-cost"})
+  (run {:suite-ns        'erp12.cbgp-lite.benchmark.suite.psb
+        :data-dir        "data/psb/"
+        :problem         "replace-space-with-newline"
+        :state-output-fn :biggest-out})
 
   )

--- a/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
@@ -91,6 +91,8 @@
                                        :stop-fn         (let [{:keys [max-generations cases]} opts]
                                                           (fn [{:keys [step step-start best new-best?]}]
                                                             (log/info :best-individual-errors (:errors best))
+                                                            (let [total (reduce + (vals @c/apply-events))]
+                                                              (log/info :apply-events (update-vals @c/apply-events #(float (/ % total)))))
                                                             (log/info "REPORT"
                                                                       {:step       step
                                                                        :duration   (- (System/currentTimeMillis) step-start)

--- a/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
@@ -10,10 +10,11 @@
 (defn problems
   [{:keys [penalty]}]
   (let [penalize-nil (fn [loss-fn]
-                       (fn [program-output correct-output]
+                       (fn wrapped-loss [program-output correct-output]
                          (if (or (nil? program-output)
+                                 ; is a sequence and contains nil
                                  (and (coll? program-output)
-                                      (some nil? program-output))) ; is a sequence and contains nil
+                                      (some nil? program-output)))
                            penalty
                            (loss-fn program-output correct-output))))]
     (update-vals

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps    {org.clojure/core.match           {:mvn/version "1.0.0"}
            com.taoensso/timbre              {:mvn/version "6.0.4"}
            io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
-           io.github.erp12/ga-clj           {:git/sha "763c0b5e9febfb9e8e5d79ac3e3afb7104d10b36"}
+           io.github.erp12/ga-clj           {:git/sha "2d255a19a9c313eed48feea3f8f8185241177066"}
            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
  :jvm-opts ["-XX:CompressedClassSpaceSize=2g"]
  :aliases {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,19 @@
-{:path    ["src"]
- :deps    {org.clojure/core.match           {:mvn/version "1.0.0"}
-           com.taoensso/timbre              {:mvn/version "6.0.4"}
-           io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
-           io.github.erp12/ga-clj           {:git/sha "2d255a19a9c313eed48feea3f8f8185241177066"}
-           clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
+{:path     ["src"]
+ :deps     {org.clojure/core.match           {:mvn/version "1.0.0"}
+            com.taoensso/timbre              {:mvn/version "6.0.4"}
+            io.github.erp12/schema-inference {:git/sha "1faafd005f6862b75c0e15f7254ebfcf6c97af4b"}
+            io.github.erp12/ga-clj           {:git/sha "2d255a19a9c313eed48feea3f8f8185241177066"}
+            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
  :jvm-opts ["-XX:CompressedClassSpaceSize=2g"]
- :aliases {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}}
-                        :ns-default build}
-           :test       {:extra-paths ["test"]
-                        :extra-deps  {expectations/clojure-test {:mvn/version "1.2.1"}
-                                      meander/epsilon           {:mvn/version "0.0.650"}
-                                      com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                                 :git/tag "v0.5.0" :git/sha "b3fd0d2"}}
-                        :main-opts   ["-m" "cognitect.test-runner"]
-                        :exec-fn     cognitect.test-runner.api/test}
-           :benchmarks {:extra-paths ["benchmarks"]
-                        :extra-deps  {org.clojure/tools.cli    {:mvn/version "1.0.206"}
-                                      net.clojars.schneau/psb2 {:mvn/version "1.1.1"}}}}}
+ :aliases  {:build      {:extra-deps {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}}
+                         :ns-default build}
+            :test       {:extra-paths ["test"]
+                         :extra-deps  {io.github.metabase/hawk {:sha "ca1775da999ed066947bd37ca5710167f4adecaa"}
+                                       meander/epsilon         {:mvn/version "0.0.650"}
+                                       com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                                  :git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+                         :main-opts   ["-m" "cognitect.test-runner"]
+                         :exec-fn     hawk.core/find-and-run-tests-cli}
+            :benchmarks {:extra-paths ["benchmarks"]
+                         :extra-deps  {org.clojure/tools.cli    {:mvn/version "1.0.206"}
+                                       net.clojars.schneau/psb2 {:mvn/version "1.1.1"}}}}}

--- a/scripts/local_runner.py
+++ b/scripts/local_runner.py
@@ -17,7 +17,8 @@ def run_cmd(opts: argparse.Namespace, run_id: int) -> str:
         f":suite-ns {suite_ns}",
         f":data-dir '\"{opts.data_dir}\"'",
         f":problem '\"{opts.problem}\"'",
-        f":type-counts-file '\"{types_file}\"'" if opts.log_types else ""
+        f":state-output-fn {opts.ast_strategy}" if opts.ast_strategy is not None else "",
+        f":type-counts-file '\"{types_file}\"'" if opts.log_types else "",
     ])
     return "; ".join(
         [
@@ -52,6 +53,11 @@ def cli_opts() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--out", help="The path to put the log files of the run captured from stdout."
+    )
+    parser.add_argument(
+        "--ast-strategy",
+        default=None,
+        help="The method of selecting and AST post-compilation.",
     )
     parser.add_argument(
         "--log-types", help="If set, an EDN file of type counts will be added to the log file dir.",
@@ -97,8 +103,9 @@ python3 scripts/local_runner.py \
     --search "ga" \
     --problem "vectors-summed" \
     --data-dir "./data/psb/" \
-    --num-runs 2 \
+    --num-runs 1 \
     --out "./data/logs/test/" \
+    --ast-strategy :biggest-out \
     --log-types \
     --parallelism 1
 """

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -183,6 +183,10 @@
   [n d]
   (if (zero? d) 0 (mod n d)))
 
+(defn safe-quot
+  [n d]
+  (if (zero? d) 0 (quot n d)))
+
 (defn sin
   [x]
   (Math/sin x))
@@ -325,7 +329,7 @@
    'int-sub             (binary-transform INT)
    'int-mult            (binary-transform INT)
    'int-div             (simple-fn [INT INT] DOUBLE)
-   'int-quot            (binary-transform INT)
+   ;'int-quot            (binary-transform INT)
    'int-mod             (binary-transform INT)
    'int-inc             (unary-transform INT)
    'int-dec             (unary-transform INT)
@@ -337,7 +341,7 @@
    'double-sub          (binary-transform DOUBLE)
    'double-mult         (binary-transform DOUBLE)
    'double-div          (binary-transform DOUBLE)
-   'double-quot         (binary-transform DOUBLE)
+   ;'double-quot         (binary-transform DOUBLE)
    'double-mod          (binary-transform DOUBLE)
    'double-inc          (unary-transform DOUBLE)
    'double-dec          (unary-transform DOUBLE)

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -123,7 +123,11 @@
           ;; correct types.
           ast (::c/ast (c/push->ast (assoc opts
                                       :push push
-                                      :locals arg-symbols)))
+                                      :locals arg-symbols
+                                      ;; @todo Experimental - record final stack AST sizes and types.
+                                      ;; Disabled to reduce concurrent compilation coordination.
+                                      :record-sketch? false
+                                      )))
           _ (log/debug "AST" ast)
           form (when ast
                  (a/ast->form ast))

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -126,8 +126,7 @@
                                       :locals arg-symbols
                                       ;; @todo Experimental - record final stack AST sizes and types.
                                       ;; Disabled to reduce concurrent compilation coordination.
-                                      :record-sketch? false
-                                      )))
+                                      :record-sketch? false)))
           _ (log/debug "AST" ast)
           form (when ast
                  (a/ast->form ast))

--- a/test/erp12/cbgp_lite/search/individual_test.clj
+++ b/test/erp12/cbgp_lite/search/individual_test.clj
@@ -2,25 +2,13 @@
   (:require [clojure.test :refer [deftest is testing]]
             [erp12.cbgp-lite.search.individual :as i]
             [erp12.cbgp-lite.task :as task]
-            [erp12.cbgp-lite.utils :as u]
-            [taoensso.timbre :as log]
-            [taoensso.timbre.appenders.core :as log-app]))
-
-(log/merge-config!
-  {:output-fn (partial log/default-output-fn {:stacktrace-fonts {}})
-   :appenders {:println (assoc (log-app/println-appender) :min-level :debug)
-               ;:spit    (assoc (log-app/spit-appender {:fname "./errors.log"}) :min-level :debug)
-               }})
+            [erp12.cbgp-lite.utils :as u]))
 
 (defn absolute-dist [a b] (Math/abs (- a b)))
 
 (deftest with-out-and-stdout-test
   (is (= {:output 2 :std-out "Hi\n"}
          (i/with-out-and-stdout (do (println "Hi") (inc 1))))))
-
-(deftest log-program-execution-errors-test
-  (is (i/log-program-execution-errors {:code   '(/ 1 0)
-                                       :output (ArithmeticException. "Divide by zero")})))
 
 (deftest compute-errors-on-case-test
   (is (= [2 1]


### PR DESCRIPTION
To use these options in the Python run launcher scripts, add the `--ast-strategy` flag with either `:biggest-out` or `:newest-out`. To use the original "search the stack" method, leave the `--ast-strategy` flag of the command.