### PR TITLE
Allows vector of out-keys in PSB problem maps

### DIFF
--- a/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/suite/psb.clj
@@ -761,7 +761,9 @@
                   (filter (fn [[k _]] (str/starts-with? (name k) "input")))
                   (sort-by first)
                   (mapv second))
-     :output (out-key case)}
+     :output (if (sequential? out-key)
+               (vec (map #(get case %) out-key))
+               (out-key case))}
     (when stdout-key
       {:std-out (stdout-key case)})))
 


### PR DESCRIPTION
To leverage this new feature, add an entry to the problem maps similar to  the following:

```clojure
:out-key [:output1 :output2]
```