### PR TITLE
Adds memory guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A genetic programming system for synthesizing programs that cover a narrow subset of the Clojure language.
 
+## Library
+
+If cbgp-lite is used as a Clojure library the jvm-opt `-Djdk.attach.allowAttachSelf` must be set by the end user.
+
 ## Benchmarking
 
 The `benchmarks` folder contains code to run `cbgp-lite` on a suite of standard benchmark problems. These can be 

--- a/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/ga.clj
@@ -89,6 +89,7 @@
                                                                                                 :num-no-ast            bu/num-no-ast-stat
                                                                                                 :num-penalties         (bu/make-num-penalty-stat (:penalty opts))
                                                                                                 :num-throwing          bu/num-throwing-stat
+                                                                                                :num-exceed-mem-guard  bu/exceed-mem-guard-stat
                                                                                                 :total-error           bu/total-error-stat
                                                                                                 :unique-behaviors      bu/unique-behaviors-stat}
                                                                                                individuals))]

--- a/benchmarks/erp12/cbgp_lite/benchmark/utils.clj
+++ b/benchmarks/erp12/cbgp_lite/benchmark/utils.clj
@@ -135,6 +135,15 @@
                     (ex-message exception)))
      exs)))
 
+(defn exceed-mem-guard-stat
+  ;; Init
+  ([] 0)
+  ;; Finalize
+  ([n] n)
+  ;; Reduce
+  ([n {:keys [exceeded-mem]}]
+   (if exceeded-mem (inc n) n)))
+
 ;; @todo (defn selections-per-parent)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,18 @@
 {:path     ["src"]
  :deps     {com.taoensso/timbre              {:mvn/version "6.0.4"}
             io.github.erp12/schema-inference {:git/sha "724355178b041a2c83abda6e68a9d4bd83d55a43"}
-            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}}
- :jvm-opts ["-XX:CompressedClassSpaceSize=2g"]
+            clj-fuzzy/clj-fuzzy              {:mvn/version "0.4.1"}
+            ;; clj-memeory-meter requires -Djdk.attach.allowAttachSelf on alias.
+            com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.4.0"}}
  :aliases  {:test       {:extra-paths ["test"]
+                         :jvm-opts    ["-Djdk.attach.allowAttachSelf"]
                          :extra-deps  {io.github.metabase/hawk   {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
                                        meander/epsilon           {:mvn/version "0.0.650"}}
                          :exec-fn     mb.hawk.core/find-and-run-tests-cli}
             :benchmarks {:extra-paths ["benchmarks"]
+                         :jvm-opts    ["-Xms2G" "-Xmx4G"
+                                       "-XX:CompressedClassSpaceSize=2g"
+                                       "-Djdk.attach.allowAttachSelf"]
                          :extra-deps  {org.clojure/tools.cli    {:mvn/version "1.0.206"}
                                        net.clojars.schneau/psb2 {:mvn/version "1.1.1"}
                                        io.github.erp12/ga-clj   {:git/sha "a6ef20b104875369a4266bd7fd4ff6cc0e7fa786"}}}}}

--- a/src/erp12/cbgp_lite/lang/ast.clj
+++ b/src/erp12/cbgp_lite/lang/ast.clj
@@ -28,7 +28,7 @@
 (defmethod ast->form :fn
   [{:keys [methods]}]
   (let [{:keys [params body]} (first methods)]
-    (list `guarded-fn 
+    (list `guarded-fn
           (mapv ast->form params)
           (ast->form body))))
 

--- a/src/erp12/cbgp_lite/lang/ast.clj
+++ b/src/erp12/cbgp_lite/lang/ast.clj
@@ -1,4 +1,5 @@
 (ns erp12.cbgp-lite.lang.ast
+  (:require [erp12.cbgp-lite.lang.lib :refer [guard]])
   (:import (clojure.lang Compiler$CompilerException)))
 
 (defmulti ast->form (fn [{:keys [op]}] op))
@@ -19,10 +20,15 @@
   [{:keys [fn args]}]
   (cons (ast->form fn) (map ast->form args)))
 
+(defmacro guarded-fn
+  "Creates an anonymous function (using fn) that throws if the returned value exceeds the memory guard."
+  [params body]
+  (list 'fn params `(guard ~body)))
+
 (defmethod ast->form :fn
   [{:keys [methods]}]
   (let [{:keys [params body]} (first methods)]
-    (list 'fn
+    (list `guarded-fn 
           (mapv ast->form params)
           (ast->form body))))
 

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -3,7 +3,27 @@
   (:require [clojure.core :as core]
             [clojure.set :as set]
             [clojure.string :as str]
+            [clj-memory-meter.core :as mm]
             [erp12.cbgp-lite.lang.schema :as schema]))
+
+(def VALUE-MAX-BYTES 50000) ;; 50 KiB
+
+(defn guard
+  [x]
+  (let [num-bytes (mm/measure x :bytes true)]
+    (if (> num-bytes VALUE-MAX-BYTES)
+      (throw (ex-info "Value too large."
+                      ;; Don't put the full value in error data because it will OOM later.
+                      {:class (type x)
+                       :bytes num-bytes}))
+      x)))
+
+(defn guarded-reduce
+  ([f coll]
+   (reduce (comp guard f) coll))
+  ([f init coll]
+   (reduce (comp guard f) init coll)))
+
 
 ;; @todo What do do about nil?
 ;; first, last, etc. return nil on empty collections.
@@ -158,11 +178,14 @@
   [i]
   (char (mod i 128)))
 
-(def concat-str (comp str/join concat))
+(def concat-str (comp guard str))
+(def append-str (comp guard str))
 (def take-str (comp str/join take))
 (def rest-str (comp str/join rest))
 (def butlast-str (comp str/join butlast))
 (def filter-str (comp str/join filter))
+(def str-replace (comp guard str/replace))
+(def str-replace-first (comp guard str/replace-first))
 
 (defn char-in? [s c] (str/includes? s (str c)))
 
@@ -240,15 +263,22 @@
   [^Character c]
   (Character/toLowerCase c))
 
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Collections
+
+(def safe-mapv (comp guard mapv))
+(def safe-mapcatv (comp guard vec mapcat))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Vector
 
-(def conj-vec (comp vec conj))
+(def conj-vec (comp guard vec conj))
 (def distinctv (comp vec distinct))
 (def mapcatv (comp vec mapcat))
-(def mapv-indexed (comp vec map-indexed))
+(def mapv-indexed (comp guard vec map-indexed))
 (def removev (comp vec remove))
-(def concatv (comp vec concat))
+(def concatv (comp guard vec concat))
 (def takev (comp vec take))
 (def restv (comp vec rest))
 (def butlastv (comp vec butlast))
@@ -310,8 +340,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Set
 
-(def conj-set (comp set conj))
-(defn map-set [f s] (into #{} (map f s)))
+(def conj-set (comp guard set conj))
+(def map-set (comp guard set map))
 (defn filter-set [pred s] (into #{} (filter pred s)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -325,6 +355,7 @@
 (def keys-vec (comp vec keys))
 (def keys-set (comp set keys))
 (def vals-vec (comp vec vals))
+(def safe-assoc (comp guard assoc))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tuple
@@ -515,7 +546,7 @@
    `digit?             (unary-pred CHAR)
    `letter?            (unary-pred CHAR)
    `concat-str         (fn-of [STRING STRING] STRING)
-   'append-str         (fn-of [STRING CHAR] STRING)
+   `append-str         (fn-of [STRING CHAR] STRING)
    `take-str           (fn-of [INT STRING] STRING)
    `safe-subs          (fn-of [STRING INT INT] STRING)
    `filter-str         (fn-of [(fn-of [CHAR] BOOLEAN) STRING] STRING)
@@ -546,8 +577,8 @@
    'index-of-char      (fn-of [STRING CHAR] INT)
    'index-of-str       (fn-of [STRING STRING] INT)
    'char-occurrences   (fn-of [STRING CHAR] INT)
-   `str/replace        (fn-of [STRING STRING STRING] STRING)
-   `str/replace-first  (fn-of [STRING STRING STRING] STRING)
+   `str-replace        (fn-of [STRING STRING STRING] STRING)
+`str-replace-first  (fn-of [STRING STRING STRING] STRING)
    `replace-char       (fn-of [STRING CHAR CHAR] STRING)
    `replace-first-char (fn-of [STRING CHAR CHAR] STRING)
    `remove-char        (fn-of [STRING CHAR] STRING)
@@ -688,7 +719,7 @@
                         :body   (fn-of [(fn-of [(s-var 'a)] BOOLEAN)
                                         (vector-of (s-var 'a))]
                                        (vector-of (s-var 'a)))}
-   `mapcatv            {:type   :scheme
+   `safe-mapcatv       {:type   :scheme
                         :s-vars ['a 'b]
                         :body   (fn-of [(fn-of [(s-var 'a)] (vector-of (s-var 'b)))
                                         (vector-of (s-var 'a))]
@@ -785,7 +816,7 @@
                                       (s-var 'v)))
    'get-or-else        (scheme (fn-of [(map-of (s-var 'k) (s-var 'v)) (s-var 'k) (s-var 'v)]
                                       (s-var 'v)))
-   'assoc              (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))
+   `safe-assoc         (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))
                                        (s-var 'k)
                                        (s-var 'v)]
                                       (map-of (s-var 'k) (s-var 'v))))
@@ -848,7 +879,6 @@
     ->vector1         vector
     ->vector2         vector
     ->vector3         vector
-    append-str        str
     char->int         int
     char-occurrences  erp12.cbgp-lite.lang.lib/occurrences-of
     comp2-fn1         comp
@@ -872,9 +902,9 @@
     double-neg        -
     empty-str?        empty?
     first-str         first
-    fold-vec          reduce
-    fold-map          reduce
-    fold-set          reduce
+    fold-vec          erp12.cbgp-lite.lang.lib/guarded-reduce
+fold-map          erp12.cbgp-lite.lang.lib/guarded-reduce
+fold-set          erp12.cbgp-lite.lang.lib/guarded-reduce
     get-or-else       get
     index-of-char     clojure.string/index-of
     index-of-str      clojure.string/index-of
@@ -895,11 +925,11 @@
     map->set          set
     map->vec          vec
     map-contains?     contains?
-    map-map           mapv
-    map-str           mapv
-    map-vec           mapv
-    map2-vec          mapv
-    mapcat-str        erp12.cbgp-lite.lang.lib/mapcatv
+    map-map           erp12.cbgp-lite.lang.lib/safe-mapv
+map-str           erp12.cbgp-lite.lang.lib/safe-mapv
+map-vec           erp12.cbgp-lite.lang.lib/safe-mapv
+map2-vec          erp12.cbgp-lite.lang.lib/safe-mapv
+mapcat-str        erp12.cbgp-lite.lang.lib/safe-mapcatv
     nth-or-else       nth
     nth-str           erp12.cbgp-lite.lang.lib/safe-nth
     partial1-fn2      partial
@@ -908,9 +938,9 @@
     range1            erp12.cbgp-lite.lang.lib/rangev
     range2            erp12.cbgp-lite.lang.lib/rangev
     range3            erp12.cbgp-lite.lang.lib/rangev
-    reduce-vec        reduce
-    reduce-map        reduce
-    reduce-set        reduce
+    reduce-vec        erp12.cbgp-lite.lang.lib/guarded-reduce
+reduce-map        erp12.cbgp-lite.lang.lib/guarded-reduce
+reduce-set        erp12.cbgp-lite.lang.lib/guarded-reduce
     right             second
     set->map          erp12.cbgp-lite.lang.lib/->map
     set->vec          vec

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -1,9 +1,9 @@
 (ns erp12.cbgp-lite.lang.lib
   (:refer-clojure :exclude [and or vector-of])
-  (:require [clojure.core :as core]
+  (:require [clj-memory-meter.core :as mm]
+            [clojure.core :as core]
             [clojure.set :as set]
             [clojure.string :as str]
-            [clj-memory-meter.core :as mm]
             [erp12.cbgp-lite.lang.schema :as schema]))
 
 (def VALUE-MAX-BYTES 50000) ;; 50 KiB
@@ -23,7 +23,6 @@
    (reduce (comp guard f) coll))
   ([f init coll]
    (reduce (comp guard f) init coll)))
-
 
 ;; @todo What do do about nil?
 ;; first, last, etc. return nil on empty collections.
@@ -263,7 +262,6 @@
   [^Character c]
   (Character/toLowerCase c))
 
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Collections
 
@@ -343,6 +341,7 @@
 (def conj-set (comp guard set conj))
 (def map-set (comp guard set map))
 (defn filter-set [pred s] (into #{} (filter pred s)))
+(def set-union (comp guard set/union))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Map
@@ -356,6 +355,7 @@
 (def keys-set (comp set keys))
 (def vals-vec (comp vec vals))
 (def safe-assoc (comp guard assoc))
+(def safe-merge (comp guard merge))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tuple
@@ -578,7 +578,7 @@
    'index-of-str       (fn-of [STRING STRING] INT)
    'char-occurrences   (fn-of [STRING CHAR] INT)
    `str-replace        (fn-of [STRING STRING STRING] STRING)
-`str-replace-first  (fn-of [STRING STRING STRING] STRING)
+   `str-replace-first  (fn-of [STRING STRING STRING] STRING)
    `replace-char       (fn-of [STRING CHAR CHAR] STRING)
    `replace-first-char (fn-of [STRING CHAR CHAR] STRING)
    `remove-char        (fn-of [STRING CHAR] STRING)
@@ -762,7 +762,7 @@
                                       (set-of (s-var 'e))))
    'map->set           (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))]
                                       (set-of (tuple-of (s-var 'k) (s-var 'v)))))
-   `set/union          (scheme (fn-of [(set-of (s-var 'e))
+   `set-union          (scheme (fn-of [(set-of (s-var 'e))
                                        (set-of (s-var 'e))]
                                       (set-of (s-var 'e))))
    `set/difference     (scheme (fn-of [(set-of (s-var 'e))
@@ -832,7 +832,7 @@
                                       (set-of (s-var 'k))))
    `vals-vec           (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))]
                                       (vector-of (s-var 'v))))
-   'merge              (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))
+   `safe-merge         (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))
                                        (map-of (s-var 'k) (s-var 'v))]
                                       (map-of (s-var 'k) (s-var 'v))))
    'count-map          (scheme (fn-of [(map-of (s-var 'k) (s-var 'v))]
@@ -903,8 +903,8 @@
     empty-str?        empty?
     first-str         first
     fold-vec          erp12.cbgp-lite.lang.lib/guarded-reduce
-fold-map          erp12.cbgp-lite.lang.lib/guarded-reduce
-fold-set          erp12.cbgp-lite.lang.lib/guarded-reduce
+    fold-map          erp12.cbgp-lite.lang.lib/guarded-reduce
+    fold-set          erp12.cbgp-lite.lang.lib/guarded-reduce
     get-or-else       get
     index-of-char     clojure.string/index-of
     index-of-str      clojure.string/index-of
@@ -926,10 +926,10 @@ fold-set          erp12.cbgp-lite.lang.lib/guarded-reduce
     map->vec          vec
     map-contains?     contains?
     map-map           erp12.cbgp-lite.lang.lib/safe-mapv
-map-str           erp12.cbgp-lite.lang.lib/safe-mapv
-map-vec           erp12.cbgp-lite.lang.lib/safe-mapv
-map2-vec          erp12.cbgp-lite.lang.lib/safe-mapv
-mapcat-str        erp12.cbgp-lite.lang.lib/safe-mapcatv
+    map-str           erp12.cbgp-lite.lang.lib/safe-mapv
+    map-vec           erp12.cbgp-lite.lang.lib/safe-mapv
+    map2-vec          erp12.cbgp-lite.lang.lib/safe-mapv
+    mapcat-str        erp12.cbgp-lite.lang.lib/safe-mapcatv
     nth-or-else       nth
     nth-str           erp12.cbgp-lite.lang.lib/safe-nth
     partial1-fn2      partial
@@ -939,8 +939,8 @@ mapcat-str        erp12.cbgp-lite.lang.lib/safe-mapcatv
     range2            erp12.cbgp-lite.lang.lib/rangev
     range3            erp12.cbgp-lite.lang.lib/rangev
     reduce-vec        erp12.cbgp-lite.lang.lib/guarded-reduce
-reduce-map        erp12.cbgp-lite.lang.lib/guarded-reduce
-reduce-set        erp12.cbgp-lite.lang.lib/guarded-reduce
+    reduce-map        erp12.cbgp-lite.lang.lib/guarded-reduce
+    reduce-set        erp12.cbgp-lite.lang.lib/guarded-reduce
     right             second
     set->map          erp12.cbgp-lite.lang.lib/->map
     set->vec          vec
@@ -973,10 +973,3 @@ reduce-set        erp12.cbgp-lite.lang.lib/guarded-reduce
                       (set)
                       (set/superset? type-ctors))))
        (into {})))
-
-(comment
-
-  (type-env 'not)
-
-  (set/difference (set (keys (lib-for-type-ctors #{:=> 'boolean?})))
-                  (set (keys (lib-for-type-ctors #{:=>})))))

--- a/src/erp12/cbgp_lite/lang/lib.clj
+++ b/src/erp12/cbgp_lite/lang/lib.clj
@@ -178,7 +178,7 @@
   (char (mod i 128)))
 
 (def concat-str (comp guard str))
-(def append-str (comp guard str))
+(def append-str str)
 (def take-str (comp str/join take))
 (def rest-str (comp str/join rest))
 (def butlast-str (comp str/join butlast))

--- a/src/erp12/cbgp_lite/search/individual.clj
+++ b/src/erp12/cbgp_lite/search/individual.clj
@@ -1,5 +1,6 @@
 (ns erp12.cbgp-lite.search.individual
-  (:require [clj-fuzzy.levenshtein :as lev]
+  (:require [clojure.string :as str]
+          [clj-fuzzy.levenshtein :as lev]
             [erp12.cbgp-lite.lang.ast :as a]
             [erp12.cbgp-lite.lang.compile :as c]
             [erp12.cbgp-lite.search.plushy :as pl]
@@ -22,7 +23,8 @@
   (try
     (with-out-and-stdout (apply func args))
     (catch Exception e
-      {:output e :std-out nil})))
+      ;; Only keep a summary of the error because the stack traces are large and cause OOM.
+      {:exception (str (.getSimpleName (class e)) ": " (.getMessage e))})))
 
 (defn errors-for-case
   "Compute errors on a single case given a program's output.
@@ -67,12 +69,11 @@
                                        :penalty     1
                                        :loss-fns    loss-fns})]
           (if (some pos? errors)
-            (if-let [ex (when (instance? Exception (:output prog-output))
-                          (:output prog-output))]
+            (if (:exception prog-output)
               {:cases-used (inc cases-used)
-               :exception  ex
+               :exception  (:exception prog-output)
                :case       case}
-              {:cases-used (inc cases-used)})
+             {:cases-used (inc cases-used)})
             (recur (rest cases)
                    (inc cases-used))))))))
 
@@ -108,7 +109,12 @@
        :total-error total-error
        :solution?   (zero? total-error)
        :cases-used  (count cases)
-       :exception   (:output (first (filter #(instance? Exception (:output %)) behavior)))})))
+       ;; Save the message of the first exception for logging and debugging.
+       :exception   (some :exception behavior)
+       ;; Record true if any of the exceptions include the error when memory limit is exceeded.
+       :exceeded-mem (boolean (seq (filter #(str/starts-with? (or (:exception %) "")
+                                                              "ExceptionInfo: Value too large")
+                                           behavior)))})))
 
 (defn make-evaluator
   [{:keys [evaluate-fn cases arg-symbols] :as opts}]

--- a/test/erp12/cbgp_lite/lang/ast_test.clj
+++ b/test/erp12/cbgp_lite/lang/ast_test.clj
@@ -51,10 +51,7 @@
                                                    :fn   {:op :var :var 'inc}
                                                    :args [{:op :local :name 'a}]}}]}
                               {:op :const :val [1 2 3]}]})
-         '(mapv (erp12.cbgp-lite.lang.ast/guarded-fn [a] (inc a)) [1 2 3])))
-
-  )
-
+         '(mapv (erp12.cbgp-lite.lang.ast/guarded-fn [a] (inc a)) [1 2 3]))))
 
 (deftest guarded-fn-test
   (let [f (a/guarded-fn [x] (vec (range x)))]

--- a/test/erp12/cbgp_lite/lang/ast_test.clj
+++ b/test/erp12/cbgp_lite/lang/ast_test.clj
@@ -51,6 +51,12 @@
                                                    :fn   {:op :var :var 'inc}
                                                    :args [{:op :local :name 'a}]}}]}
                               {:op :const :val [1 2 3]}]})
-         '(mapv (fn [a] (inc a)) [1 2 3])))
+         '(mapv (erp12.cbgp-lite.lang.ast/guarded-fn [a] (inc a)) [1 2 3])))
 
   )
+
+
+(deftest guarded-fn-test
+  (let [f (a/guarded-fn [x] (vec (range x)))]
+    (is (= [0 1 2] (f 3)))
+    (is (thrown? clojure.lang.ExceptionInfo (f 1e6)))))

--- a/test/erp12/cbgp_lite/lang/compile_test.clj
+++ b/test/erp12/cbgp_lite/lang/compile_test.clj
@@ -432,7 +432,8 @@
                                             :dealiases lib/dealiases})
         _ (is (= type {:type :vector :child {:type 'int?}}))
         form (a/ast->form ast)
-        _ (is (matches? (mapv (fn [?a] (inc ?a)) [1 2 3])
+        _ (println "!!!" form)
+_ (is (matches? (erp12.cbgp-lite.lang.lib/safe-mapv (erp12.cbgp-lite.lang.ast/guarded-fn [?a] (inc ?a)) [1 2 3])
                         form))
         func (eval `(fn [] ~form))]
     (is (= [2 3 4] (func)))))
@@ -463,7 +464,7 @@
                                             :dealiases {}})
         _ (is (= type {:type :vector :child {:type 'double?}}))
         form (a/ast->form ast)
-        _ (is (= form '(repeatedly 5 (fn [] (rand)))))
+        _ (is (= form '(repeatedly 5 (erp12.cbgp-lite.lang.ast/guarded-fn [] (rand)))))
         func (eval `(fn [] ~form))]
     (doseq [x (func)]
       (is (double? x)))))

--- a/test/erp12/cbgp_lite/lang/compile_test.clj
+++ b/test/erp12/cbgp_lite/lang/compile_test.clj
@@ -432,8 +432,7 @@
                                             :dealiases lib/dealiases})
         _ (is (= type {:type :vector :child {:type 'int?}}))
         form (a/ast->form ast)
-        _ (println "!!!" form)
-_ (is (matches? (erp12.cbgp-lite.lang.lib/safe-mapv (erp12.cbgp-lite.lang.ast/guarded-fn [?a] (inc ?a)) [1 2 3])
+        _ (is (matches? (erp12.cbgp-lite.lang.lib/safe-mapv (erp12.cbgp-lite.lang.ast/guarded-fn [?a] (inc ?a)) [1 2 3])
                         form))
         func (eval `(fn [] ~form))]
     (is (= [2 3 4] (func)))))

--- a/test/erp12/cbgp_lite/lang/lib_test.clj
+++ b/test/erp12/cbgp_lite/lang/lib_test.clj
@@ -1,7 +1,7 @@
 (ns erp12.cbgp-lite.lang.lib-test
-  (:require [clojure.test :refer [deftest testing is]]
-            [erp12.cbgp-lite.lang.lib :as l]
-            [clojure.set :as set])
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest testing is]]
+            [erp12.cbgp-lite.lang.lib :as l])
   (:import (clojure.lang ExceptionInfo)))
 
 (deftest safe-sqrt-test

--- a/test/erp12/cbgp_lite/search/individual_test.clj
+++ b/test/erp12/cbgp_lite/search/individual_test.clj
@@ -27,8 +27,8 @@
            (i/evaluate-until-first-failure (assoc opts :func #(do (print %2) (+ %1 %2))))))
     (is (= {:cases-used 1}
            (i/evaluate-until-first-failure (assoc opts :func #(do (print %2) (* %1 %2))))))
-    (is (instance? ArithmeticException
-                   (:exception (i/evaluate-until-first-failure (assoc opts :func #(do (print %2) (/ %1 0)))))))))
+    (is (= "ArithmeticException: Divide by zero"
+         (:exception (i/evaluate-until-first-failure (assoc opts :func #(do (print %2) (/ %1 0)))))))))
 
 (deftest evaluate-full-behavior-test
   (let [opts {:cases    [{:inputs [1 2] :output 3 :std-out "2"}
@@ -44,7 +44,8 @@
             :errors      [0 0 0 0 0 0]
             :solution?   true
             :total-error 0
-            :exception   nil}))
+            :exception   nil
+            :exceeded-mem false}))
     (is (= (i/evaluate-full-behavior (assoc opts :func #(do (println %2) (* %1 %2))))
            {:behavior    (list {:output 2 :std-out "2\n"}
                                {:output -1 :std-out "1\n"}
@@ -53,7 +54,8 @@
             :errors      [1 1 1 1 0 1]
             :solution?   false
             :total-error 5
-            :exception   nil}))))
+            :exception   nil
+            :exceeded-mem false}))))
 
 (deftest make-evaluator-test
   (let [evaluator (i/make-evaluator (-> {:input->type {'input1 {:type 'double?}
@@ -76,7 +78,8 @@
             :total-error 2.5
             :cases-used  1
             :solution?   false
-            :exception   nil}))
+            :exception   nil
+            :exceeded-mem false}))
     ;(is (= (dissoc (factory (list)
     ;                        {:cases [{:inputs [1.5 2] :output 3.5}]})
     ;               :func)
@@ -129,7 +132,8 @@
               :total-error 0.0
               :cases-used  3
               :solution?   true
-              :exception   nil}
+              :exception   nil
+              :exceeded-mem false}
              (let [gn (list {:gene :var :name 'input1}
                             {:gene :var :name 'input2}
                             {:gene :var :name 'double}


### PR DESCRIPTION
Adds a memory guard to all functions in the function set that can grow the size of a value. The guarded functions throw an exception if the returned value exceeds the hardcoded threshold of 50 KiB.

Also adds and evolutionary statistic that counts the number of individuals per generation that exceed the memory guard on at least one case.

This feature is implemented with clj-memory-meter which requires the jvm-opt `-Djdk.attach.allowAttachSelf` to be set. This has been added to this project's aliases that are used to run tests and benchmark runs but users that run `cbgp-lite` as a library will need to set the jvm-opt themselves.

This PR has been tested on a small number of runs for count-odds, get-vals-of-key, and sum-vector-vals. 